### PR TITLE
Fix Docker build: compile TypeScript in container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 node_modules
 .git
 .github
-dist
 test
 coverage
 *.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ FROM node:22-slim
 RUN apt-get update && apt-get install -y git sqlite3 curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY package*.json ./
-RUN npm ci --production
-COPY dist/ ./dist/
+COPY package*.json tsconfig.json ./
+COPY src/ ./src/
+RUN npm ci && npm run build && npm prune --production
 
 VOLUME /data/docs
 VOLUME /app/config


### PR DESCRIPTION
## Summary

- Dockerfile was trying to `COPY dist/` but `.dockerignore` excluded it, causing build failure
- Changed to copy source + tsconfig, run `npm run build` inside the container, then `npm prune --production` to keep the image lean
- Removed `dist` from `.dockerignore` since it's no longer copied (it's built in-place)

## Test plan

- [x] `docker build -t ghcr.io/nullproof-studio/en-quire:latest .` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)