### PR TITLE
Fix replaceSection dropping trailing newline (#9)

### DIFF
--- a/src/document/section-ops.ts
+++ b/src/document/section-ops.ts
@@ -78,7 +78,7 @@ export function replaceSection(
     const before = markdown.slice(0, node.headingStartOffset);
     const after = markdown.slice(node.bodyEndOffset);
     const separator = newContent.startsWith('\n') ? '' : '\n';
-    return before + newHeadingLine + separator + newContent + after;
+    return before + newHeadingLine + separator + ensureTrailingNewlines(newContent) + after;
   }
 
   if (replaceHeading === true) {
@@ -91,9 +91,9 @@ export function replaceSection(
       // Content doesn't include a heading — preserve the original heading
       const headingLine = markdown.slice(node.headingStartOffset, node.bodyStartOffset);
       const separator = newContent.startsWith('\n') ? '' : '\n';
-      return before + headingLine + separator + newContent + after;
+      return before + headingLine + separator + ensureTrailingNewlines(newContent) + after;
     }
-    return before + newContent + after;
+    return before + ensureTrailingNewlines(newContent) + after;
   }
 
   // Replace body only, preserve heading
@@ -102,7 +102,7 @@ export function replaceSection(
 
   // Ensure newContent starts with a newline for proper separation from heading
   const separator = newContent.startsWith('\n') ? '' : '\n';
-  return before + separator + newContent + after;
+  return before + separator + ensureTrailingNewlines(newContent) + after;
 }
 
 /**
@@ -113,6 +113,16 @@ export function replaceSection(
  */
 function stripHeadingMarkers(heading: string): string {
   return heading.replace(/^#+\s*/, '');
+}
+
+/**
+ * Ensure content ends with a double newline so the next section's
+ * heading isn't concatenated to the replaced content.
+ */
+function ensureTrailingNewlines(content: string): string {
+  if (content.endsWith('\n\n')) return content;
+  if (content.endsWith('\n')) return content + '\n';
+  return content + '\n\n';
 }
 
 /**

--- a/test/unit/document/section-ops.test.ts
+++ b/test/unit/document/section-ops.test.ts
@@ -117,6 +117,38 @@ describe('insertSection', () => {
   });
 });
 
+describe('replaceSection — trailing newline preservation', () => {
+  it('ensures next section heading is not concatenated when content lacks trailing newline', () => {
+    const md = '# Doc\n\n## A\n\nContent A.\n\n## B\n\nContent B.\n';
+    const tree = parse(md);
+    const result = replaceSection(md, tree, { type: 'text', text: 'A' }, 'Replaced content.');
+    expect(result).toContain('Replaced content.\n\n## B');
+    expect(result).not.toMatch(/Replaced content\.## B/);
+  });
+
+  it('does not add extra newlines when content already ends with \\n\\n', () => {
+    const md = '# Doc\n\n## A\n\nContent A.\n\n## B\n\nContent B.\n';
+    const tree = parse(md);
+    const result = replaceSection(md, tree, { type: 'text', text: 'A' }, 'Replaced content.\n\n');
+    expect(result).toContain('Replaced content.\n\n## B');
+    expect(result).not.toContain('Replaced content.\n\n\n');
+  });
+
+  it('ensures trailing newlines with replaceHeading=true', () => {
+    const md = '# Doc\n\n## A\n\nContent A.\n\n## B\n\nContent B.\n';
+    const tree = parse(md);
+    const result = replaceSection(md, tree, { type: 'text', text: 'A' }, '## A\n\nNew content.', true);
+    expect(result).toContain('New content.\n\n## B');
+  });
+
+  it('ensures trailing newlines with replaceHeading as string', () => {
+    const md = '# Doc\n\n## A\n\nContent A.\n\n## B\n\nContent B.\n';
+    const tree = parse(md);
+    const result = replaceSection(md, tree, { type: 'text', text: 'A' }, 'New content.', 'Renamed');
+    expect(result).toContain('New content.\n\n## B');
+  });
+});
+
 describe('insertSection — heading sanitisation', () => {
   it('strips leading # markers from heading parameter', () => {
     const md = '# Doc\n\n## A\n\nContent A.\n';


### PR DESCRIPTION
## Summary

- All `replaceSection()` code paths now ensure replacement content ends with `\n\n` so the next section's heading isn't concatenated to the replaced content
- Added `ensureTrailingNewlines()` helper that normalises content endings (no newline → `\n\n`, single `\n` → `\n\n`, already `\n\n` → unchanged)

Closes #9

## Test plan

- [x] 4 new tests covering trailing newline for all replace paths (body-only, replaceHeading=true, replaceHeading as string, idempotent when already correct)
- [x] Full test suite passes (166 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)