### PR TITLE
fix: reject appended content with headings that break section hierarchy

### DIFF
--- a/src/document/section-ops.ts
+++ b/src/document/section-ops.ts
@@ -139,6 +139,33 @@ function ensureTrailingNewlines(content: string): string {
 }
 
 /**
+ * Check if content contains ATX headings at or above the given level.
+ * Ignores headings inside fenced code blocks.
+ */
+function checkForBreakingHeadings(content: string, sectionLevel: number): void {
+  let inCodeBlock = false;
+  for (const line of content.split('\n')) {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) continue;
+
+    const match = trimmed.match(/^(#{1,6})\s/);
+    if (match) {
+      const headingLevel = match[1].length;
+      if (headingLevel <= sectionLevel) {
+        throw new ValidationError(
+          `Cannot append content containing a level-${headingLevel} heading to a level-${sectionLevel} section. ` +
+          `Use doc_insert_section to add sibling or higher-level sections.`,
+        );
+      }
+    }
+  }
+}
+
+/**
  * Insert a new section relative to an anchor section.
  * Returns the new markdown string.
  */
@@ -213,6 +240,16 @@ export function appendToSection(
   content: string,
 ): string {
   const node = resolveSingleSection(tree, address);
+
+  // Guard: reject content containing markdown headings at the same or higher level.
+  // Only applies to markdown sections (heading level > 0 with # markers).
+  if (node.heading.level > 0) {
+    const headingLine = markdown.slice(node.headingStartOffset, node.bodyStartOffset);
+    const isMarkdown = headingLine.trimStart().startsWith('#');
+    if (isMarkdown) {
+      checkForBreakingHeadings(content, node.heading.level);
+    }
+  }
 
   const insertOffset = node.bodyEndOffset;
   const before = markdown.slice(0, insertOffset);

--- a/test/unit/document/section-ops.test.ts
+++ b/test/unit/document/section-ops.test.ts
@@ -431,3 +431,55 @@ describe('insertSection — duplicate sibling guard', () => {
     )).not.toThrow();
   });
 });
+
+describe('appendToSection — heading guard', () => {
+  it('rejects content with a same-level heading', () => {
+    const md = '# Doc\n\n## Tools\n\nExisting tools.\n';
+    const tree = parse(md);
+    expect(() => appendToSection(md, tree,
+      { type: 'text', text: 'Tools' },
+      '## Another Section\n\nContent.\n'
+    )).toThrow(/heading/i);
+  });
+
+  it('rejects content with a higher-level heading', () => {
+    const md = '# Doc\n\n## Tools\n\nExisting tools.\n';
+    const tree = parse(md);
+    expect(() => appendToSection(md, tree,
+      { type: 'text', text: 'Tools' },
+      '# Top Level\n\nContent.\n'
+    )).toThrow(/heading/i);
+  });
+
+  it('allows plain body content without headings', () => {
+    const md = '# Doc\n\n## Tools\n\nExisting tools.\n';
+    const tree = parse(md);
+    const result = appendToSection(md, tree,
+      { type: 'text', text: 'Tools' },
+      '- New tool item\n- Another item\n'
+    );
+    expect(result).toContain('New tool item');
+    expect(result).toContain('Existing tools.');
+  });
+
+  it('allows content with lower-level (child) headings', () => {
+    const md = '# Doc\n\n## Tools\n\nExisting tools.\n';
+    const tree = parse(md);
+    const result = appendToSection(md, tree,
+      { type: 'text', text: 'Tools' },
+      '### Sub-tool\n\nDetail.\n'
+    );
+    expect(result).toContain('### Sub-tool');
+  });
+
+  it('does not reject headings inside code blocks', () => {
+    const md = '# Doc\n\n## Guide\n\nSome guide.\n';
+    const tree = parse(md);
+    const result = appendToSection(md, tree,
+      { type: 'text', text: 'Guide' },
+      '```markdown\n## Example Heading\n```\n'
+    );
+    expect(result).toContain('## Example Heading');
+  });
+
+});

--- a/test/unit/document/yaml-parser.test.ts
+++ b/test/unit/document/yaml-parser.test.ts
@@ -295,6 +295,17 @@ version: '3.8'
   });
 });
 
+describe('YAML parser — append does not check for markdown headings', () => {
+  it('allows appending content with # characters (YAML comments)', () => {
+    const yaml = 'config:\n  key: value\n';
+    const tree = parser.parse(yaml);
+    const address = parser.parseAddress('config');
+    // # in YAML is a comment, not a heading — should not be rejected
+    const result = appendToSection(yaml, tree, address, '  # new comment\n  other: data\n');
+    expect(result).toContain('# new comment');
+  });
+});
+
 describe('YAML parser — comment preservation', () => {
   it('preserves comments when deleting a section', () => {
     const yaml = '# Top comment\na: 1\n# Middle comment\nb: 2\nc: 3\n';


### PR DESCRIPTION
## Summary

Closes #23

`appendToSection` now validates content before appending. If the content contains a markdown heading at the same or higher level as the target section, the write is rejected with a clear `ValidationError` directing the agent to use `doc_insert_section` instead.

- **Same-level heading** (`## X` appended to a `## Y` section) — rejected
- **Higher-level heading** (`# X` appended to a `## Y` section) — rejected
- **Lower-level heading** (`### X` appended to a `## Y` section) — allowed (valid child)
- **Plain body content** — always allowed (the intended use case)
- **Headings inside fenced code blocks** — ignored (not structural)
- **YAML sections** — unaffected (`#` is a comment in YAML, not a heading)

## Test plan

- [x] 275 tests pass
- [x] TypeScript compiles clean
- [x] Rejects same-level heading in appended content
- [x] Rejects higher-level heading in appended content
- [x] Allows plain body content
- [x] Allows lower-level (child) headings
- [x] Ignores headings inside code blocks
- [x] YAML append with `#` comments still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)