### PR TITLE
fix: auto-strip duplicate heading from replacement content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ npm-debug.log*
 
 # TypeScript
 *.tsbuildinfo
+
+
 en-quire.config.yaml
 a2a-poc/
 docs/session-memory/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ npm-debug.log*
 # TypeScript
 *.tsbuildinfo
 en-quire.config.yaml
+a2a-poc/
+docs/session-memory/
+en-quire-repo-setup.md
+en-quire-spec.md

--- a/code-structure.md
+++ b/code-structure.md
@@ -1,0 +1,142 @@
+# Code Structure Documentation
+
+This document explores and documents the structure of the en-quire codebase.
+
+## Overview
+
+This document contains findings from exploring the en-quire codebase structure.
+## Project Overview
+
+**en-quire** is a structured document management system for agent systems with governance features. It's implemented as an MCP (Model Context Protocol) server.
+
+## Entry Point and Server Setup
+
+## Core Modules
+
+## Shared Utilities ([`src/shared/`](src/shared/))
+
+- [`file-utils.ts`](src/shared/file-utils.ts): File I/O with path traversal protection, encoding normalization
+- [`diff.ts`](src/shared/diff.ts): Unified diff generation using `diff` package
+- [`errors.ts`](src/shared/errors.ts): Custom error classes (EnquireError, NotFoundError, AddressResolutionError, PermissionDeniedError, etc.)
+- [`logger.ts`](src/shared/logger.ts): Winston logger with console and optional file output
+- [`types.ts`](src/shared/types.ts): Core type definitions (SectionNode, SectionAddress variants, OutlineEntry, SearchResult, etc.)
+
+## Git Integration ([`src/git/`](src/git/))
+
+- [`operations.ts`](src/git/operations.ts): Git operations wrapper (commit, branch, switch, status)
+- [`detector.ts`](src/git/detector.ts): Auto-detect git repository presence
+- [`commit-message.ts`](src/git/commit-message.ts): Structured commit message and proposal branch naming
+
+## RBAC ([`src/rbac/`](src/rbac/))
+
+- [`permissions.ts`](src/rbac/permissions.ts): Permission checking with micromatch path matching
+- [`resolver.ts`](src/rbac/resolver.ts): Resolve caller identity from config
+- [`types.ts`](src/rbac/types.ts): Permission type definitions
+
+## Testing ([`test/`](test/))
+
+- **Unit tests**: [`test/unit/`](test/unit/) - Individual module tests
+- **Integration tests**: [`test/integration/`](test/integration/) - Tool integration tests
+- **E2E tests**: [`test/e2e/`](test/e2e/) - End-to-end scenarios
+- **Fixtures**: [`test/fixtures/docs/`](test/fixtures/docs/) - Test markdown/YAML files
+
+## Key Design Patterns
+
+1. **Section Tree**: Documents parsed into hierarchical section nodes with byte offsets
+2. **Address Resolution**: Multiple address types (text, path, index, pattern) for section targeting
+3. **Parser Registry**: Extensible format support (Markdown, YAML) with extension mapping
+4. **Write Mode**: Two modes - direct write or proposal (git branch + PR)
+5. **Search Index**: FTS5 with structural ranking (heading boost, depth penalty)
+6. **Permission Scopes**: Path-based permissions with glob patterns
+### Tools ([`src/tools/`](src/tools/))
+
+**Read Tools:**
+- [`doc-outline.ts`](src/tools/read/doc-outline.ts): Get document heading structure with depth control
+- [`doc-read.ts`](src/tools/read/doc-read.ts): Read document with pagination
+- [`doc-read-section.ts`](src/tools/read/doc-read-section.ts): Read specific section by address
+- [`doc-list.ts`](src/tools/read/doc-list.ts): List documents across roots with optional outline
+
+**Write Tools:**
+- [`doc-create.ts`](src/tools/write/doc-create.ts): Create new document with optional proposal mode
+- [`doc-replace-section.ts`](src/tools/write/doc-replace-section.ts): Replace section content
+- [`doc-insert-section.ts`](src/tools/write/doc-insert-section.ts): Insert section before/after anchor
+- [`doc-append-section.ts`](src/tools/write/doc-append-section.ts): Append content to section
+- [`doc-delete-section.ts`](src/tools/write/doc-delete-section.ts): Delete section and children
+- [`doc-find-replace.ts`](src/tools/write/doc-find-replace.ts): Find and replace text with preview
+- [`doc-rename.ts`](src/tools/write/doc-rename.ts): Rename document within root
+- [`doc-generate-toc.ts`](src/tools/write/doc-generate-toc.ts): Generate table of contents
+- [`doc-set-value.ts`](src/tools/write/doc-set-value.ts): Set value at path (YAML) or replace section (Markdown)
+
+**Write Helpers:**
+- [`write-helpers.ts`](src/tools/write/write-helpers.ts): Core write execution with git commit, index update, diff generation
+
+**Status/Search/Governance/Admin Tools:**
+- [`doc-status.ts`](src/tools/status/doc-status.ts): Check index status, modified files, pending proposals
+- [`doc-search.ts`](src/tools/search/doc-search.ts): Full-text search with scope filtering
+- [`doc-proposals.ts`](src/tools/governance/doc-proposals.ts): List, diff, approve, reject proposals
+- [`doc-exec.ts`](src/tools/admin/doc-exec.ts): Execute commands in root context
+### Configuration ([`src/config/`](src/config/))
+
+- [`loader.ts`](src/config/loader.ts): Loads YAML config, validates with Zod schema, resolves document roots
+- [`schema.ts`](src/config/schema.ts): Zod schemas for config validation (Callers, Scopes, Permissions, Git settings)
+- [`roots.ts`](src/config/roots.ts): File path resolution with root prefix handling, path traversal protection
+- [`defaults.ts`](src/config/defaults.ts): Default configuration values
+
+### Document Processing ([`src/document/`](src/document/))
+
+- [`parser.ts`](src/document/parser.ts): Unified processor for Markdown (with frontmatter and GFM)
+- [`markdown-parser.ts`](src/document/markdown-parser.ts): Markdown parser implementation with preamble support
+- [`yaml-parser.ts`](src/document/yaml-parser.ts): YAML parser that treats keys as section headings
+- [`section-tree.ts`](src/document/section-tree.ts): Builds hierarchical section tree from AST
+- [`section-address.ts`](src/document/section-address.ts): Parses addresses (text, path, index, pattern)
+- [`section-ops.ts`](src/document/section-ops.ts): Read/modify operations on sections
+- [`ast-utils.ts`](src/document/ast-utils.ts): AST utilities (toString, countCodePoints, offsetToLine)
+- [`serializer.ts`](src/document/serializer.ts): AST to markdown serialization (for validation)
+- [`parser-registry.ts`](src/document/parser-registry.ts): Registry for format-specific parsers
+- [`encoding.ts`](src/document/encoding.ts): Character encoding detection and normalization
+
+### Search ([`src/search/`](src/search/))
+
+- [`database.ts`](src/search/database.ts): SQLite database with WAL mode and performance pragmas
+- [`schema.ts`](src/search/schema.ts): FTS5 table and metadata schema
+- [`indexer.ts`](src/search/indexer.ts): Documents sections into FTS5 with mtime tracking
+- [`query.ts`](src/search/query.ts): Query sanitization and ranking (heading boost, depth penalty)
+- [`sync.ts`](src/search/sync.ts): Batched index synchronization with change detection
+### Main Entry Point ([`src/index.ts`](src/index.ts))
+
+The application starts at [`main()`](src/index.ts:20) which:
+1. Parses command-line arguments (config path)
+2. Loads and validates configuration via [`loadConfig()`](src/config/loader.ts:13)
+3. Initializes logging
+4. Opens the search database
+5. Configures document roots with Git operations
+6. Syncs search index (blocking or background based on config)
+7. Starts either stdio or HTTP transport server
+
+### Server Creation ([`src/server.ts`](src/server.ts))
+
+The [`createServer()`](src/server.ts:49) function creates an MCP server with:
+- **Read Tools**: `doc_outline`, `doc_read_section`, `doc_read`, `doc_list`
+- **Write Tools**: `doc_replace_section`, `doc_insert_section`, `doc_append_section`, `doc_delete_section`, `doc_create`, `doc_find_replace`, `doc_rename`, `doc_generate_toc`, `doc_set_value`
+- **Status Tools**: `doc_status`
+- **Search Tools**: `doc_search`
+- **Governance Tools**: `doc_proposals_list`, `doc_proposal_diff`, `doc_proposal_approve`, `doc_proposal_reject`
+- **Admin Tools**: `doc_exec`
+
+All handlers are wrapped with error handling that returns structured error responses.
+### Key Technologies
+
+- **Language**: TypeScript (Node.js >=22.0.0)
+- **MCP SDK**: @modelcontextprotocol/sdk v1.12.1
+- **Database**: better-sqlite3 for full-text search indexing
+- **Markdown Processing**: unified, remark-parse, remark-frontmatter, remark-gfm
+- **Git Integration**: simple-git
+- **Configuration**: YAML with Zod schema validation
+
+### Core Functionality
+
+- Document management with hierarchical section addressing
+- Multiple document format support (Markdown, YAML)
+- Full-text search with optional semantic search
+- Git-based governance with proposals and approvals
+- RBAC (Role-Based Access Control) for permissions

--- a/src/document/section-ops.ts
+++ b/src/document/section-ops.ts
@@ -98,23 +98,28 @@ export function replaceSection(
   }
 
   // Replace body only, preserve heading
+  // Auto-strip a leading heading from content if it matches the target section.
+  // Agents frequently include "### Heading\n\n" at the start of replacement content,
+  // which would create a duplicate heading since replaceSection preserves the original.
+  const strippedContent = stripLeadingDuplicateHeading(newContent, node.heading.text);
+
   const before = markdown.slice(0, node.bodyStartOffset);
   const after = markdown.slice(node.bodyEndOffset);
 
   // For sections without a heading line (e.g. __preamble, YAML keys),
   // don't add a blank line separator — just replace the body directly.
   if (node.headingStartOffset === node.bodyStartOffset) {
-    return before + ensureTrailingNewlines(newContent) + after;
+    return before + ensureTrailingNewlines(strippedContent) + after;
   }
 
   // YAML keys: `before` ends with \n (bodyStartOffset is at a line start).
   // No blank line separator needed — strip leading newlines and splice directly.
   if (before.endsWith('\n')) {
-    const stripped = newContent.replace(/^\n*/, '');
+    const stripped = strippedContent.replace(/^\n*/, '');
     return before + ensureTrailingNewlines(stripped) + after;
   }
 
-  const normalized = newContent.replace(/^\n*/, '');
+  const normalized = strippedContent.replace(/^\n*/, '');
   return before + '\n\n' + ensureTrailingNewlines(normalized) + after;
 }
 
@@ -126,6 +131,27 @@ export function replaceSection(
  */
 function stripHeadingMarkers(heading: string): string {
   return heading.replace(/^#+\s*/, '');
+}
+
+/**
+ * Strip a leading heading line from content if its text matches the
+ * target section heading.  Agents often include the heading in
+ * replacement content even though replaceSection preserves it.
+ */
+function stripLeadingDuplicateHeading(content: string, headingText: string): string {
+  // Strip leading whitespace/newlines before checking for a heading line
+  const trimmed = content.replace(/^\n*/, '');
+  // Match ATX heading: #{1,6}, space(s), text, optional trailing ##+ markers
+  const match = trimmed.match(/^#{1,6}\s+(.+?)(?:\s+#+\s*)?$/m);
+  if (!match) return content;
+  const contentHeadingText = match[1].trim();
+  if (contentHeadingText === headingText) {
+    // Remove the heading line and any blank lines after it
+    const headingEnd = trimmed.indexOf('\n', match.index!);
+    if (headingEnd === -1) return '';
+    return trimmed.slice(headingEnd).replace(/^\n*/, '');
+  }
+  return content;
 }
 
 /**

--- a/test/fixtures/docs/append-level-test.md
+++ b/test/fixtures/docs/append-level-test.md
@@ -1,0 +1,13 @@
+# Append Level Test
+
+## Section Alpha
+
+Alpha content.
+
+### Subsection A1
+
+Subsection content.
+
+# This Is A Higher Level Heading
+
+This would break the entire document hierarchy.

--- a/test/fixtures/docs/append-retest.md
+++ b/test/fixtures/docs/append-retest.md
@@ -1,0 +1,15 @@
+# Append Validation Retest
+
+## Section One
+
+Some content here.
+
+
+### Subsection Under One
+
+This is a valid child heading — lower level than the target section.
+## Section Two
+
+More content here.
+
+This is just plain text appended to the section. No headings.

--- a/test/fixtures/docs/append-validation-test.md
+++ b/test/fixtures/docs/append-validation-test.md
@@ -1,0 +1,13 @@
+# Append Validation Test
+
+## Section One
+
+Some content here.
+
+
+## This Should Be Blocked
+
+This heading is the same level as Section One, which would break the hierarchy.
+## Section Two
+
+More content here.

--- a/test/fixtures/docs/container-test.md
+++ b/test/fixtures/docs/container-test.md
@@ -1,0 +1,21 @@
+# Container Test
+
+## Has Content
+
+This section has body text.
+
+### Also Has Content
+
+This child has text too.
+
+## Empty Container
+
+### Child Under Empty
+
+Content lives here, not in the parent.
+
+### Another Child
+
+More content.
+
+## Truly Empty

--- a/test/fixtures/docs/docker-compose.yaml
+++ b/test/fixtures/docs/docker-compose.yaml
@@ -1,0 +1,41 @@
+version: '3.8'
+
+services:
+  api:
+    image: node:22-slim
+
+      
+
+    environment:
+      NODE_ENV: production
+      PORT: 3100
+      LOG_LEVEL: debug
+      DATABASE_URL: postgres://localhost:5432/app
+
+
+    volumes:
+      - ./data:/data
+      - ./config:/app/config:ro
+    ports:
+      - "3100:3100"
+    restart: unless-stopped
+
+  worker:
+    image: node:22-slim
+    command: node worker.js
+    environment:
+      NODE_ENV: production
+      QUEUE_URL: redis://redis:6379
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis-data:/data
+    ports:
+      - "6379:6379"
+
+volumes:
+  redis-data:
+    driver: local

--- a/test/fixtures/docs/duplicate-insert-test.md
+++ b/test/fixtures/docs/duplicate-insert-test.md
@@ -1,0 +1,9 @@
+# Insert Test
+
+## Section Alpha
+
+Alpha content.
+
+## Section Beta
+
+Beta content.

--- a/test/fixtures/docs/duplicate-levels-test.md
+++ b/test/fixtures/docs/duplicate-levels-test.md
@@ -1,0 +1,13 @@
+# Level Test
+
+## Service Alpha
+
+### Overview
+
+Alpha overview.
+
+## Service Beta
+
+### Overview
+
+Beta overview.

--- a/test/fixtures/docs/enquire-config.yaml
+++ b/test/fixtures/docs/enquire-config.yaml
@@ -1,0 +1,56 @@
+name: en-quire
+version: "0.2.0"
+
+server:
+  transport: stdio
+  port: 8080
+  log_level: error
+
+search:
+  fulltext: true
+  semantic:
+    enabled: false
+    endpoint: "http://localhost:8000/v1/embeddings"
+    model: "all-MiniLM-L6-v2"
+    dimensions: 768
+
+
+git:
+  auto_commit: true
+  remote: null
+
+callers:
+  michelle:
+    key: sk-michelle-ops-v3
+    scopes:
+      - path: "sops/**"
+        permissions:
+          - read
+          - write
+          - search
+      - path: "skills/**"
+        permissions:
+          - read
+          - propose
+          - search
+  analyst:
+    key: "sk-analyst-v2"
+    scopes:
+      - path: "**"
+        permissions:
+          - read
+          - search
+      - path: "reports/**"
+        permissions:
+          - read
+          - write
+          - search
+  sofia:
+    key: "sk-sofia-ops"
+    scopes:
+      - path: "sops/**"
+        permissions:
+          - read
+          - write
+          - search
+

--- a/test/fixtures/docs/fix-validation-2.md
+++ b/test/fixtures/docs/fix-validation-2.md
@@ -1,0 +1,30 @@
+# Fix Validation Test
+
+Preamble content.
+
+## Section Alpha
+
+Alpha content line 1.
+Alpha content line 2.
+
+## Section Beta
+
+Replaced beta without leading newline.
+This should still get a blank line after the heading.
+
+## Section Gamma
+
+Gamma content line 1.
+
+### Gamma Child One
+
+Gamma child one content.
+
+### Gamma Child Two
+
+Gamma child two content.
+
+## Section Delta
+
+Delta content line 1.
+Delta content line 2.

--- a/test/fixtures/docs/fix-validation.md
+++ b/test/fixtures/docs/fix-validation.md
@@ -1,0 +1,39 @@
+# Fix Validation Test
+
+Preamble content.
+
+## Section One
+Replaced content with no leading blank line.
+
+## Section Two
+Replaced with leading blank line included.
+
+### Child Alpha
+
+Child alpha content.
+
+### Child Alpha
+
+Duplicate child name under different context.
+
+## Section Three
+
+Section three body content.
+
+## Overview
+
+First overview section.
+
+## Details
+
+### Overview
+
+Nested overview — same name as top-level.
+
+### Other Child
+
+Other child content.
+
+## Final Section
+
+Final section body.

--- a/test/fixtures/docs/frontmatter-test.md
+++ b/test/fixtures/docs/frontmatter-test.md
@@ -1,0 +1,24 @@
+
+
+---
+title: "Frontmatter Test Document"
+author: "Andy"
+version: "1.1"
+tags:
+  - testing
+  - frontmatter
+  - preamble-support
+status: published
+---
+
+# Main Content
+
+This is the body of the document.
+
+## Section One
+
+First section content.
+
+## Section Two
+
+Second section content.

--- a/test/fixtures/docs/habilidad-triaje-correo.md
+++ b/test/fixtures/docs/habilidad-triaje-correo.md
@@ -1,0 +1,60 @@
+# Habilidad: Triaje de Correo Electrónico
+
+**Propósito:** Instrucciones para clasificar y enrutar correos entrantes de clientes hacia los flujos de trabajo apropiados.
+
+---
+
+## Cuándo Usar Esta Habilidad
+
+Activar cuando se recibe un correo electrónico de un cliente que:
+- Describe un incidente, pérdida, daño o robo
+- Solicita información sobre el estado de una reclamación
+- Contiene lenguaje relacionado con siniestros ("mi coche fue golpeado", "hubo una inundación", "necesito hacer una reclamación")
+- Es una correspondencia reenviada por otro agente para triaje
+
+## Flujo de Trabajo Principal
+
+### Paso 1: Identificación del Cliente
+
+Buscar al cliente por nombre, correo electrónico o referencia. Si no se encuentra, crear un registro nuevo con los datos disponibles del correo.
+
+### Paso 2: Clasificación del Correo
+
+Determinar la categoría:
+- **Nuevo siniestro** — primera notificación de pérdida (FNOL)
+- **Seguimiento** — actualización sobre una reclamación existente
+- **Consulta general** — pregunta sobre póliza, cobertura o procedimiento
+- **Queja** — insatisfacción con el servicio o la resolución
+
+
+- **Duplicado** — el cliente reporta el mismo incidente más de una vez. Vincular a la reclamación existente.
+
+### Paso 3: Enrutamiento
+
+| Categoría | Acción | Agente Destino |
+|-----------|--------|----------------|
+| Nuevo siniestro | Crear reclamación, solicitar documentación | Michelle |
+| Seguimiento | Actualizar reclamación existente | Michelle |
+| Consulta general | Responder directamente o escalar | Minnie |
+| Queja | Escalar inmediatamente con contexto completo | Andy |
+
+### Paso 4: Confirmación
+
+Enviar acuse de recibo al cliente en su idioma preferido. Incluir:
+- Número de referencia (si aplica)
+- Próximos pasos esperados
+- Tiempo estimado de respuesta
+
+## Errores Comunes a Evitar
+
+- **No clasificar sin leer el correo completo.** El asunto puede ser engañoso.
+- **No asumir el idioma del cliente.** Verificar el idioma del correo y responder en el mismo.
+- **No cerrar sin confirmar.** Siempre verificar que la acción se ejecutó correctamente antes de marcar como completado.
+
+## Herramientas Disponibles
+
+- `comms-InboxGet` — obtener contenido completo del correo
+- `customer_ro-search` — buscar cliente por nombre o email
+- `Sparqiva_CreateClaim` — abrir nueva reclamación
+- `Sparqiva_UpdateClaim` — actualizar reclamación existente
+- `comms-Send` — enviar respuesta al cliente

--- a/test/fixtures/docs/preamble-fix-test.md
+++ b/test/fixtures/docs/preamble-fix-test.md
@@ -1,0 +1,15 @@
+---
+title: "Preamble Fix Test"
+version: "1.1"
+status: published
+tags:
+  - testing
+---
+
+# Document Title
+
+Body content here.
+
+## Section One
+
+First section.

--- a/test/fixtures/docs/preamble-retest.md
+++ b/test/fixtures/docs/preamble-retest.md
@@ -1,0 +1,17 @@
+---
+title: "Preamble Retest"
+version: "2.0"
+status: published
+tags:
+  - testing
+---
+
+# Main Content
+
+Body text.
+
+## Section One
+
+Updated section one content via doc_set_value.
+This should work as syntactic sugar over doc_replace_section.
+

--- a/test/fixtures/docs/quote-test.yaml
+++ b/test/fixtures/docs/quote-test.yaml
@@ -1,0 +1,9 @@
+name: "quote-test"
+version: "1.0.0"
+
+settings:
+  api_key: "sk-original-key-123"
+  endpoint: "http://localhost:3000"
+  enabled: true
+  count: 42
+  unquoted_string: hello-world

--- a/test/fixtures/docs/section-test.md
+++ b/test/fixtures/docs/section-test.md
@@ -1,0 +1,29 @@
+# Test Document
+
+Preamble content before any sections.
+
+## Section Alpha
+
+Replaced alpha content with proper spacing.
+Second line of alpha.
+
+## Section Beta
+Replaced beta content.
+This is the new beta.
+
+## Section Gamma
+
+Gamma content line 1.
+
+### Gamma Child One
+
+Replaced gamma child one. Checking child two still exists.
+
+### Gamma Child Two
+
+Gamma child two content.
+
+## Section Delta
+
+Delta content line 1.
+Delta content line 2.

--- a/test/fixtures/docs/sofia-agente.md
+++ b/test/fixtures/docs/sofia-agente.md
@@ -1,0 +1,49 @@
+# Sofía — Agente de Operaciones
+
+## Rol
+
+Eres Sofía, agente de operaciones para el equipo de atención al cliente. Tu responsabilidad principal es gestionar el flujo de trabajo diario: triaje de correos, seguimiento de reclamaciones y coordinación con otros agentes.
+
+## Tono y Comunicación
+
+- Profesional pero cercana
+- Siempre en el idioma del cliente
+- Respuestas claras y estructuradas
+- Evitar jerga técnica innecesaria
+
+## Reglas de Ejecución
+
+### Acciones Requieren Herramientas
+
+No puedes realizar acciones de creación, actualización o cierre solo con texto. Si una acción cambia estado, DEBES usar la herramienta correspondiente.
+
+### Escalamiento
+
+Escalar a Andy cuando:
+- El cliente expresa insatisfacción grave
+- La reclamación supera los €50.000 de autorización
+- Hay un conflicto entre la póliza y la solicitud del cliente
+- El cliente solicita hablar con un supervisor humano
+
+En todos los casos, incluir un resumen completo del contexto antes de escalar.
+
+### Coordinación con Otros Agentes
+
+- Puedes solicitar trabajo a otro agente (ej: "@Michelle revisa esta reclamación")
+- Esto se trata como una solicitud, no como una acción completada
+- No marcar como completado sin evidencia de la herramienta
+
+## Herramientas Principales
+
+- triaje-correo — clasificación y enrutamiento de correos entrantes
+- comms — gestión de comunicaciones (inbox, hilos, envío)
+- customer — búsqueda y gestión de registros de clientes
+- Sparqiva — reclamaciones, pólizas y planes de servicio
+
+## Auto-Mejora
+
+Cuando identifiques una mejora en tu enfoque o uso de herramientas durante una conversación:
+1. Usa en-quire `doc_read` para revisar tu perfil actual
+2. Redacta el cambio específico
+3. Usa `doc_append_section` o `doc_replace_section` en modo **write** para aplicar el cambio
+4. Informa al usuario qué cambiaste y por qué

--- a/test/fixtures/docs/yaml-fix-test.yaml
+++ b/test/fixtures/docs/yaml-fix-test.yaml
@@ -1,0 +1,44 @@
+version: '3.8'
+
+services:
+  api:
+    image: node:22-slim
+    environment:
+      
+
+      NODE_ENV: production
+      PORT: 3100
+      LOG_LEVEL: debug
+      DATABASE_URL: postgres://localhost:5432/app
+
+    volumes:
+      - ./data:/data
+      - ./config:/app/config:ro
+    ports:
+      - "3100:3100"
+    restart: unless-stopped
+
+  worker:
+    image: node:22-slim
+    command: node worker.js
+    environment:
+      NODE_ENV: production
+      QUEUE_URL: redis://redis:6379
+    depends_on:
+      - redis
+
+  redis:
+    
+
+    image: redis:7.2-alpine
+    command: redis-server --maxmemory 256mb
+    volumes:
+      - redis-data:/data
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
+
+volumes:
+  redis-data:
+    driver: local

--- a/test/fixtures/docs/yaml-retest-2.yaml
+++ b/test/fixtures/docs/yaml-retest-2.yaml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  api:
+    image: node:22-slim
+    environment:
+      NODE_ENV: production
+      PORT: 3100
+      LOG_LEVEL: info
+
+      DEBUG: "true"
+
+    volumes:
+      - ./data:/data
+    ports:
+      - "3100:3100"
+
+  worker:
+    image: node:22-slim
+    environment:
+      NODE_ENV: production
+      QUEUE_URL: redis://redis:6379
+
+volumes:
+  redis-data:
+    driver: local

--- a/test/fixtures/docs/yaml-retest.yaml
+++ b/test/fixtures/docs/yaml-retest.yaml
@@ -1,0 +1,39 @@
+version: '3.8'
+
+services:
+  api:
+    image: node:22-slim
+    environment:
+      NODE_ENV: production
+    PORT: 3100
+
+
+    volumes:
+      - ./data:/data
+      - ./config:/app/config:ro
+    ports:
+      - "3100:3100"
+    restart: always
+
+  worker:
+    image: node:22-slim
+    command: node worker.js
+    environment:
+      NODE_ENV: production
+      QUEUE_URL: redis://redis:6379
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7.2-alpine
+    command: redis-server --maxmemory 256mb
+    volumes:
+      - redis-data:/data
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
+
+volumes:
+  redis-data:
+    driver: local

--- a/test/unit/document/section-ops.test.ts
+++ b/test/unit/document/section-ops.test.ts
@@ -483,3 +483,91 @@ describe('appendToSection — heading guard', () => {
   });
 
 });
+
+describe('replaceSection — auto-strip duplicate heading from content (#27)', () => {
+  it('strips leading heading from content when it matches the target section', () => {
+    const md = '# Doc\n\n## A\n\nOld content.\n\n## B\n\nKeep this.\n';
+    const tree = parse(md);
+    const result = replaceSection(md, tree, { type: 'text', text: 'A' },
+      '## A\n\nNew content.\n');
+    expect(result).toContain('## A');
+    expect(result).toContain('New content.');
+    // Should NOT have a duplicate heading
+    expect(result).not.toMatch(/## A[\s\S]*## A/);
+  });
+
+  it('strips leading heading with different marker level', () => {
+    const md = '# Doc\n\n## A\n\nOld content.\n\n## B\n\nKeep this.\n';
+    const tree = parse(md);
+    // Agent uses ### instead of ## but same text
+    const result = replaceSection(md, tree, { type: 'text', text: 'A' },
+      '### A\n\nNew content.\n');
+    expect(result).toContain('## A');
+    expect(result).toContain('New content.');
+    expect(result).not.toMatch(/## A[\s\S]*### A/);
+  });
+
+  it('does not strip heading when text differs', () => {
+    const md = '# Doc\n\n## A\n\nOld content.\n\n## B\n\nKeep this.\n';
+    const tree = parse(md);
+    const result = replaceSection(md, tree, { type: 'text', text: 'A' },
+      '### Different Heading\n\nNew content.\n');
+    // Different heading text should be kept as body content
+    expect(result).toContain('### Different Heading');
+  });
+
+  it('strips heading with leading newlines in content', () => {
+    const md = '# Doc\n\n## A\n\nOld content.\n\n## B\n\nKeep this.\n';
+    const tree = parse(md);
+    const result = replaceSection(md, tree, { type: 'text', text: 'A' },
+      '\n\n## A\n\nNew content.\n');
+    expect(result).toContain('## A');
+    expect(result).toContain('New content.');
+    expect(result).not.toMatch(/## A[\s\S]*## A/);
+  });
+
+  it('strips heading with trailing ATX closing markers', () => {
+    const md = '# Doc\n\n## A\n\nOld content.\n\n## B\n\nKeep this.\n';
+    const tree = parse(md);
+    const result = replaceSection(md, tree, { type: 'text', text: 'A' },
+      '## A ##\n\nNew content.\n');
+    expect(result).toContain('## A');
+    expect(result).toContain('New content.');
+    expect(result).not.toMatch(/## A[\s\S]*## A/);
+  });
+
+  it('strips heading with extra spaces after markers', () => {
+    const md = '# Doc\n\n## A\n\nOld content.\n\n## B\n\nKeep this.\n';
+    const tree = parse(md);
+    const result = replaceSection(md, tree, { type: 'text', text: 'A' },
+      '##  A\n\nNew content.\n');
+    expect(result).toContain('## A');
+    expect(result).toContain('New content.');
+    expect(result).not.toMatch(/## A[\s\S]*## A/);
+  });
+
+  it('strips heading at all six ATX levels', () => {
+    // Test with a deeply nested h6 section
+    const md = '# A\n\n## B\n\n### C\n\n#### D\n\n##### E\n\n###### F\n\nDeep content.\n';
+    const tree = parse(md);
+    const result = replaceSection(md, tree, { type: 'text', text: 'F' },
+      '###### F\n\nUpdated deep content.\n');
+    expect(result).toContain('###### F');
+    expect(result).toContain('Updated deep content.');
+    const matches = result.match(/###### F/g);
+    expect(matches?.length).toBe(1);
+  });
+
+  it('handles real-world agent content with heading and body', () => {
+    const md = '# WTW\n\n## Operational Excellence & Capabilities\n\n### Digital Transformation Initiatives (2024-2026)\n\nOld data.\n';
+    const tree = parse(md);
+    const result = replaceSection(md, tree,
+      { type: 'text', text: 'Digital Transformation Initiatives (2024-2026)' },
+      '### Digital Transformation Initiatives (2024-2026)\n\n**Strategic Investments:**\n- WIRL Platform Enhancement\n- Cloud Migration\n');
+    expect(result).toContain('### Digital Transformation Initiatives (2024-2026)');
+    expect(result).toContain('Strategic Investments');
+    // No duplicate heading
+    const matches = result.match(/Digital Transformation Initiatives \(2024-2026\)/g);
+    expect(matches?.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Agents frequently include the section heading in `doc_replace_section` content (e.g. `### Digital Transformation Initiatives (2024-2026)\n\nBody...`), causing duplicate headings that trigger the sibling guard
- `replaceSection()` now silently strips a leading heading from content when its text matches the target section — same defensive philosophy as the existing `stripAddressMarkers()` and `stripHeadingMarkers()`
- Handles edge cases: leading newlines, trailing ATX closing markers (`## A ##`), extra spaces after markers, and all six heading levels

Closes #27

## Test plan

- [x] Test: strips leading heading when it matches target section
- [x] Test: strips heading with different marker level (e.g. `###` vs `##`)
- [x] Test: does not strip heading when text differs
- [x] Test: strips heading with leading newlines in content
- [x] Test: strips heading with trailing ATX closing markers
- [x] Test: strips heading with extra spaces after markers
- [x] Test: strips heading at all six ATX levels
- [x] Test: real-world agent content (WTW Digital Transformation scenario)
- [x] Full test suite: 283 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)