### PR TITLE
fix: expand replacement range when content contains child headings

### DIFF
--- a/src/document/section-ops.ts
+++ b/src/document/section-ops.ts
@@ -103,8 +103,14 @@ export function replaceSection(
   // which would create a duplicate heading since replaceSection preserves the original.
   const strippedContent = stripLeadingDuplicateHeading(newContent, node.heading.text);
 
+  // If replacement content contains child-level headings, replace the entire section
+  // body including children (sectionEndOffset) to avoid duplicating existing children.
+  // Otherwise replace only the body text (bodyEndOffset), preserving children.
+  const contentHasChildHeadings = hasChildHeadings(strippedContent, node.heading.level);
+  const endOffset = contentHasChildHeadings ? node.sectionEndOffset : node.bodyEndOffset;
+
   const before = markdown.slice(0, node.bodyStartOffset);
-  const after = markdown.slice(node.bodyEndOffset);
+  const after = markdown.slice(endOffset);
 
   // For sections without a heading line (e.g. __preamble, YAML keys),
   // don't add a blank line separator — just replace the body directly.
@@ -131,6 +137,30 @@ export function replaceSection(
  */
 function stripHeadingMarkers(heading: string): string {
   return heading.replace(/^#+\s*/, '');
+}
+
+/**
+ * Check if content contains ATX headings deeper than the given level.
+ * Ignores headings inside fenced code blocks.
+ * Used to decide whether replacement content includes subsection headings
+ * that would duplicate existing children if only the body were replaced.
+ */
+function hasChildHeadings(content: string, parentLevel: number): boolean {
+  let inCodeBlock = false;
+  for (const line of content.split('\n')) {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) continue;
+
+    const match = trimmed.match(/^(#{1,6})\s/);
+    if (match && match[1].length > parentLevel) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/test/fixtures/docs/financial-performance.md
+++ b/test/fixtures/docs/financial-performance.md
@@ -1,0 +1,46 @@
+# Anthropic's $380B Valuation and Enterprise Leadership Signal AI Infrastructure Dominance
+
+## Executive Summary
+
+Anthropic has emerged as the leading enterprise AI provider with 32–40% market share.
+
+## Financial Performance
+
+### Financial Summary
+
+| Metric | 2023 | 2024 | 2025 (Est.) | 2026 (Proj.) |
+|--------|------|------|-------------|---------------|
+| **Revenue** | ~$10M | $850M | $19–26B | $35–45B |
+| **YoY Growth** | N/A | 8,40% | ~2,0–3,0% | ~70–80% |
+| **Employees** | ~10 | ~30 | ~70–1,0 | ~1,50+ |
+| **Valuation** | $10B (Series C) | $15B (Series D) | $350B (Series F) | $380B (Series G) |
+
+*Note: 2023–2024 figures from public reports; 2025 estimates based on Sacra data and funding announcements; 2026 projections derived from run-rate statements*
+
+### Trend Analysis
+
+**Revenue trajectory**: Anthropic has demonstrated the fastest revenue growth of any AI company, accelerating from $850M in 2024 to an estimated $19–26B run-rate by early 2026. This represents a **23–31x increase in ~12 months**.
+
+The acceleration reflects:
+- Enterprise buyers moving from pilot to production (larger contracts)
+- Cloud partnerships scaling distribution (AWS, Azure commitments)
+- Model improvements driving usage expansion (Opus 4.6 capabilities)
+
+**Capital efficiency**: The company has raised ~$50B total across all rounds while achieving $20B+ revenue run-rate—capital intensive but generating real commercial traction.
+
+### Peer Benchmarking
+
+| Metric | Anthropic | OpenAI (Est.) | Notes |
+|--------|-----------|---------------|-------|
+| Revenue (2025 est.) | $19–26B | ~$20–25B | Comparable scale |
+| Enterprise market share | 32% | 25% | Anthropic leading in enterprise |
+| Valuation | $380B | ~$30–40B (variable) | Similar range |
+| Revenue multiple (EV/Rev) | ~15–20x | ~12–18x | Anthropic trades at premium |
+
+### So What
+
+Anthropic's financial trajectory is unprecedented—even by AI standards. The key question is sustainability: can 70–80% growth continue, or will the company normalise toward 30–50% as the market matures? At $380B valuation, investors are pricing in sustained leadership and multi-trillion-dollar TAM capture.
+
+## Strategic Outlook
+
+The company is well-positioned for continued growth through 2027.

--- a/test/unit/document/section-ops.test.ts
+++ b/test/unit/document/section-ops.test.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parseMarkdown } from '../../../src/document/parser.js';
@@ -569,5 +569,200 @@ describe('replaceSection — auto-strip duplicate heading from content (#27)', (
     // No duplicate heading
     const matches = result.match(/Digital Transformation Initiatives \(2024-2026\)/g);
     expect(matches?.length).toBe(1);
+  });
+});
+
+describe('replaceSection — body-only replace duplicates child sections (#29)', () => {
+  const fixtureName = 'financial-performance.md';
+  let originalMd: string;
+
+  beforeEach(() => {
+    originalMd = loadFixture(fixtureName);
+  });
+
+  afterEach(() => {
+    // Verify the fixture file is unchanged (replaceSection is pure — returns a new string)
+    const current = loadFixture(fixtureName);
+    expect(current).toBe(originalMd);
+  });
+
+  it('body-only replace with subsection headings should not duplicate existing children', () => {
+    const tree = parse(originalMd);
+
+    // This is what an agent does: reads the section, rewrites it with updated subsections
+    const agentContent =
+      '### Financial Summary\n' +
+      '| Metric | 2023 | 2024 |\n' +
+      '|--------|------|------|\n' +
+      '| **Revenue** | ~$10M | $850M |\n\n' +
+      '### Funding History\n' +
+      '| Round | Date | Amount |\n' +
+      '|-------|------|--------|\n' +
+      '| Series A | Dec 2021 | $30M |\n\n' +
+      '### Key Financial Observations\n' +
+      '1. Unprecedented growth velocity.\n';
+
+    const result = replaceSection(
+      originalMd,
+      tree,
+      { type: 'text', text: 'Financial Performance' },
+      agentContent,
+    );
+
+    // The original children should NOT survive alongside the new content
+    const financialSummaryCount = (result.match(/### Financial Summary/g) || []).length;
+    expect(financialSummaryCount).toBe(1);
+
+    // Original child "Trend Analysis" should be gone — agent didn't include it
+    expect(result).not.toContain('### Trend Analysis');
+
+    // Original child "Peer Benchmarking" should be gone
+    expect(result).not.toContain('### Peer Benchmarking');
+
+    // Original child "So What" should be gone
+    expect(result).not.toContain('### So What');
+
+    // New content should be present
+    expect(result).toContain('### Funding History');
+    expect(result).toContain('### Key Financial Observations');
+
+    // Sibling sections should be unaffected
+    expect(result).toContain('## Executive Summary');
+    expect(result).toContain('## Strategic Outlook');
+  });
+
+  it('body-only replace with no subsection headings should leave children intact', () => {
+    const tree = parse(originalMd);
+
+    // Agent sends plain body text — no subsection headings
+    const result = replaceSection(
+      originalMd,
+      tree,
+      { type: 'text', text: 'Financial Performance' },
+      'Updated intro paragraph for the financial section.\n',
+    );
+
+    // Children should still be there since we only replaced the body
+    expect(result).toContain('### Financial Summary');
+    expect(result).toContain('### Trend Analysis');
+    expect(result).toContain('### Peer Benchmarking');
+    expect(result).toContain('### So What');
+    expect(result).toContain('Updated intro paragraph');
+  });
+
+  it('partial child replacement: a,b,c → b,c,d removes a and appends d', () => {
+    // Fixture has children: Financial Summary (a), Trend Analysis (b),
+    // Peer Benchmarking (c), So What (d) — agent drops first, keeps middle two, adds new
+    const tree = parse(originalMd);
+
+    const agentContent =
+      '### Trend Analysis\n' +
+      'Updated trend analysis content.\n\n' +
+      '### Peer Benchmarking\n' +
+      'Updated benchmarking content.\n\n' +
+      '### Risk Assessment\n' +
+      'New risk section added by agent.\n';
+
+    const result = replaceSection(
+      originalMd,
+      tree,
+      { type: 'text', text: 'Financial Performance' },
+      agentContent,
+    );
+
+    // Dropped child should be gone
+    expect(result).not.toContain('### Financial Summary');
+    // Kept children should appear exactly once with updated content
+    expect((result.match(/### Trend Analysis/g) || []).length).toBe(1);
+    expect(result).toContain('Updated trend analysis content.');
+    expect((result.match(/### Peer Benchmarking/g) || []).length).toBe(1);
+    expect(result).toContain('Updated benchmarking content.');
+    // Original "So What" should be gone (agent omitted it)
+    expect(result).not.toContain('### So What');
+    // New child should be present
+    expect(result).toContain('### Risk Assessment');
+    expect(result).toContain('New risk section added by agent.');
+
+    // Siblings unaffected
+    expect(result).toContain('## Executive Summary');
+    expect(result).toContain('## Strategic Outlook');
+  });
+
+  it('handles deeply nested children (3+ levels)', () => {
+    const md =
+      '# Report\n\n' +
+      '## Analysis\n\n' +
+      '### Overview\n\n' +
+      'Intro text.\n\n' +
+      '#### Subsection A\n\n' +
+      'Detail A.\n\n' +
+      '##### Deep Detail A1\n\n' +
+      'Very deep content.\n\n' +
+      '#### Subsection B\n\n' +
+      'Detail B.\n\n' +
+      '### Conclusion\n\n' +
+      'Wrapping up.\n\n' +
+      '## Appendix\n\n' +
+      'References.\n';
+
+    const tree = parse(md);
+
+    const agentContent =
+      '#### Subsection X\n\n' +
+      'Replaced detail X.\n\n' +
+      '##### Deep Detail X1\n\n' +
+      'New deep content.\n\n' +
+      '##### Deep Detail X2\n\n' +
+      'Another deep section.\n\n' +
+      '#### Subsection Y\n\n' +
+      'Replaced detail Y.\n';
+
+    const result = replaceSection(
+      md,
+      tree,
+      { type: 'text', text: 'Overview' },
+      agentContent,
+    );
+
+    // Original deep children should be gone
+    expect(result).not.toContain('#### Subsection A');
+    expect(result).not.toContain('##### Deep Detail A1');
+    expect(result).not.toContain('#### Subsection B');
+
+    // New deep children should be present
+    expect(result).toContain('#### Subsection X');
+    expect(result).toContain('##### Deep Detail X1');
+    expect(result).toContain('##### Deep Detail X2');
+    expect(result).toContain('#### Subsection Y');
+
+    // Sibling "Conclusion" and parent-sibling "Appendix" unaffected
+    expect(result).toContain('### Conclusion');
+    expect(result).toContain('Wrapping up.');
+    expect(result).toContain('## Appendix');
+    expect(result).toContain('References.');
+  });
+
+  it('ignores child-level headings inside fenced code blocks', () => {
+    const tree = parse(originalMd);
+
+    // Content has a ### heading only inside a code block — not a real child heading
+    const agentContent =
+      'Here is an example:\n\n' +
+      '```markdown\n' +
+      '### Example Heading\n' +
+      'This is just a code sample.\n' +
+      '```\n';
+
+    const result = replaceSection(
+      originalMd,
+      tree,
+      { type: 'text', text: 'Financial Performance' },
+      agentContent,
+    );
+
+    // Children should be preserved — the heading was inside a code block
+    expect(result).toContain('### Financial Summary');
+    expect(result).toContain('### Trend Analysis');
+    expect(result).toContain('Here is an example:');
   });
 });


### PR DESCRIPTION
## Summary

Closes #29.

- Body-only `replaceSection` now detects when replacement content includes subsection headings (via `hasChildHeadings`) and extends the splice range from `bodyEndOffset` to `sectionEndOffset`, replacing existing children instead of duplicating them
- When replacement content has no child-level headings, existing behaviour is preserved (body-only splice, children intact)
- Headings inside fenced code blocks are ignored

## Test plan

- [x] Body-only replace with subsection headings does not duplicate existing children
- [x] Body-only replace without subsection headings preserves children
- [x] Partial child replacement (a,b,c → b,c,d) correctly removes a, updates b/c, appends d
- [x] Deeply nested children (3+ levels: h3 → h4 → h5) handled correctly
- [x] Headings inside fenced code blocks do not trigger child-heading detection
- [x] Sibling sections unaffected in all cases
- [x] Full test suite passes (285 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)