### PR TITLE
Bearer token auth on HTTP transport (#62)

### DIFF
--- a/packages/en-core/src/config/loader.ts
+++ b/packages/en-core/src/config/loader.ts
@@ -44,6 +44,22 @@ export function loadConfig(configPath: string): ResolvedConfig {
 
   const validated = result.data;
 
+  // HTTP transport requires every caller to have a Bearer `key` — the
+  // auto-select fallback in resolver.ts is stdio-only, so an HTTP request
+  // without a recognisable token is indistinguishable from any other. Fail
+  // loudly at startup rather than at the first 401.
+  if (validated.transport === 'streamable-http') {
+    const missing = Object.entries(validated.callers)
+      .filter(([, caller]) => !caller.key)
+      .map(([id]) => id);
+    if (missing.length > 0) {
+      throw new ValidationError(
+        `HTTP transport requires every caller to have a Bearer 'key'. ` +
+        `Missing keys for caller(s): ${missing.join(', ')}.`,
+      );
+    }
+  }
+
   // Resolve document roots
   const document_roots: Record<string, ResolvedRoot> = {};
   for (const [name, root] of Object.entries(validated.document_roots)) {

--- a/packages/en-core/src/index.ts
+++ b/packages/en-core/src/index.ts
@@ -17,6 +17,7 @@ export * from './config/roots.js';
 export * from './config/schema.js';
 
 // RBAC
+export * from './rbac/http-auth.js';
 export * from './rbac/permissions.js';
 export * from './rbac/resolver.js';
 export * from './rbac/types.js';

--- a/packages/en-core/src/rbac/http-auth.ts
+++ b/packages/en-core/src/rbac/http-auth.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { CallerConfig, CallerIdentity } from '../shared/types.js';
+
+export type AuthResult =
+  | { ok: true; caller: CallerIdentity }
+  | { ok: false; reason: 'missing' | 'malformed' | 'invalid' };
+
+/**
+ * Extract the token from a `Bearer <token>` Authorization header.
+ * Returns null when:
+ *   - the header is absent or empty
+ *   - the scheme is anything other than `Bearer` (case-sensitive — "bearer"
+ *     also returns null so misconfigurations surface loudly rather than
+ *     silently passing on some clients but not others)
+ *   - the scheme is `Bearer` but the token part is missing or blank
+ */
+export function parseBearerToken(authHeader: string | undefined): string | null {
+  if (!authHeader) return null;
+  const match = /^Bearer (.+)$/.exec(authHeader);
+  if (!match) return null;
+  const token = match[1];
+  return token.length > 0 ? token : null;
+}
+
+/**
+ * Authenticate an incoming request against the configured callers.
+ *
+ * Comparison is constant-time via SHA-256 hash + `timingSafeEqual` — both
+ * sides are reduced to a fixed 32-byte buffer before comparison, so token
+ * length is not leaked through timing. Every configured caller is iterated
+ * even after a match to equalise loop timing.
+ *
+ * Callers without a `key` (stdio-only callers) are skipped outright.
+ */
+export function authenticateBearer(
+  authHeader: string | undefined,
+  callers: Record<string, CallerConfig>,
+): AuthResult {
+  if (authHeader === undefined) {
+    return { ok: false, reason: 'missing' };
+  }
+
+  const token = parseBearerToken(authHeader);
+  if (token === null) {
+    return { ok: false, reason: 'malformed' };
+  }
+
+  const tokenHash = createHash('sha256').update(token).digest();
+  let matched: { id: string; config: CallerConfig } | null = null;
+
+  for (const [id, config] of Object.entries(callers)) {
+    if (!config.key) continue;
+    const keyHash = createHash('sha256').update(config.key).digest();
+    const equal = timingSafeEqual(tokenHash, keyHash);
+    if (equal && matched === null) {
+      matched = { id, config };
+    }
+    // deliberately continue iterating so total time is independent of
+    // match position
+  }
+
+  if (matched) {
+    return {
+      ok: true,
+      caller: { id: matched.id, scopes: matched.config.scopes },
+    };
+  }
+  return { ok: false, reason: 'invalid' };
+}

--- a/packages/en-core/src/rbac/resolver.ts
+++ b/packages/en-core/src/rbac/resolver.ts
@@ -4,15 +4,31 @@ import type { CallerIdentity, ResolvedConfig } from '../shared/types.js';
 /**
  * Resolve caller identity from config and transport context.
  *
- * For v0.1 (stdio transport), caller is identified by:
- * 1. If only one caller is configured, use it as default
- * 2. If a caller ID is provided in transport headers, match it
- * 3. Fall back to a default caller with read+search permissions
+ * Intended for **stdio transport only** — stdio is inherently a single
+ * process, so a startup-time caller resolution is safe. The HTTP transport
+ * must authenticate every request with `authenticateBearer`; see
+ * [rbac/http-auth.ts](../rbac/http-auth.ts).
+ *
+ * Resolution order (stdio):
+ * 1. If a caller ID is provided, match it exactly.
+ * 2. If only one caller is configured, use it as default.
+ * 3. Fall back to a synthetic `_default` caller with read+search only.
+ *
+ * If called when `config.transport === 'streamable-http'` without a
+ * `callerId`, throws — the single-caller fallback is a serious security
+ * hole under HTTP (any request would inherit full permissions).
  */
 export function resolveCaller(
   config: ResolvedConfig,
   callerId?: string,
 ): CallerIdentity {
+  if (config.transport === 'streamable-http' && !callerId) {
+    throw new Error(
+      'resolveCaller() auto-select is not safe under HTTP transport. ' +
+      'Use authenticateBearer() on each request instead.',
+    );
+  }
+
   const callerEntries = Object.entries(config.callers);
 
   // If a specific caller is requested, find it
@@ -26,7 +42,8 @@ export function resolveCaller(
     }
   }
 
-  // If only one caller configured, use it as default
+  // If only one caller configured, use it as default (stdio only —
+  // the HTTP guard above already returned for that path).
   if (callerEntries.length === 1) {
     const [id, entry] = callerEntries[0];
     return {

--- a/packages/en-core/test/unit/config/http-auth-validation.test.ts
+++ b/packages/en-core/test/unit/config/http-auth-validation.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadConfig } from '@nullproof-studio/en-core';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'http-auth-cfg-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeConfig(yaml: string): string {
+  const path = join(dir, 'config.yaml');
+  writeFileSync(path, yaml);
+  return path;
+}
+
+describe('loadConfig — HTTP transport caller-key validation', () => {
+  it('throws when HTTP transport is configured and any caller lacks a key', () => {
+    const path = writeConfig(`
+document_roots:
+  notes:
+    path: .
+transport: streamable-http
+callers:
+  alice:
+    key: sk-alice-valid
+    scopes:
+      - path: "**"
+        permissions: [read]
+  bob:
+    scopes:
+      - path: "**"
+        permissions: [read]
+`);
+    // Error must mention both "key" (what's required) and "bob" (who's missing)
+    expect(() => loadConfig(path)).toThrow(/key/i);
+    expect(() => loadConfig(path)).toThrow(/bob/);
+  });
+
+  it('passes when HTTP transport is configured and every caller has a key', () => {
+    const path = writeConfig(`
+document_roots:
+  notes:
+    path: .
+transport: streamable-http
+callers:
+  alice:
+    key: sk-alice-valid
+    scopes:
+      - path: "**"
+        permissions: [read]
+  bob:
+    key: sk-bob-valid
+    scopes:
+      - path: "**"
+        permissions: [read]
+`);
+    const config = loadConfig(path);
+    expect(config.transport).toBe('streamable-http');
+    expect(Object.keys(config.callers).sort()).toEqual(['alice', 'bob']);
+  });
+
+  it('passes when stdio transport is configured even if callers lack keys', () => {
+    const path = writeConfig(`
+document_roots:
+  notes:
+    path: .
+transport: stdio
+callers:
+  alice:
+    scopes:
+      - path: "**"
+        permissions: [read]
+`);
+    const config = loadConfig(path);
+    expect(config.transport).toBe('stdio');
+    expect(config.callers.alice.key).toBeUndefined();
+  });
+
+  it('passes when HTTP transport has no callers configured at all', () => {
+    // No callers means no one can authenticate — the server starts but every
+    // /mcp request will get 401. That's a valid (if useless) state; the
+    // startup validator only complains about misconfigured callers, not
+    // absent ones.
+    const path = writeConfig(`
+document_roots:
+  notes:
+    path: .
+transport: streamable-http
+`);
+    expect(() => loadConfig(path)).not.toThrow();
+  });
+});

--- a/packages/en-core/test/unit/rbac/http-auth.test.ts
+++ b/packages/en-core/test/unit/rbac/http-auth.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect } from 'vitest';
+import { parseBearerToken, authenticateBearer } from '@nullproof-studio/en-core';
+import type { CallerConfig } from '@nullproof-studio/en-core';
+
+const callers: Record<string, CallerConfig> = {
+  alice: {
+    key: 'sk-alice-secret-0123456789abcdef',
+    scopes: [{ path: '**', permissions: ['read'] }],
+  },
+  bob: {
+    key: 'sk-bob-another-token-fedcba9876543210',
+    scopes: [{ path: 'bob/**', permissions: ['read', 'write'] }],
+  },
+  // A caller without a key — should never match any token
+  keyless: {
+    scopes: [{ path: '**', permissions: ['read'] }],
+  },
+};
+
+describe('parseBearerToken', () => {
+  it('extracts the token after "Bearer "', () => {
+    expect(parseBearerToken('Bearer abc123')).toBe('abc123');
+  });
+
+  it('returns null for undefined', () => {
+    expect(parseBearerToken(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseBearerToken('')).toBeNull();
+  });
+
+  it('returns null for a non-Bearer scheme', () => {
+    expect(parseBearerToken('Basic dXNlcjpwYXNz')).toBeNull();
+    expect(parseBearerToken('Token abc123')).toBeNull();
+  });
+
+  it('returns null for "Bearer" with no token', () => {
+    expect(parseBearerToken('Bearer')).toBeNull();
+    expect(parseBearerToken('Bearer ')).toBeNull();
+  });
+
+  it('is case-sensitive on the scheme (rejects "bearer")', () => {
+    // RFC 7235 says the scheme is case-insensitive, but in practice clients
+    // always send "Bearer" capitalised. Rejecting the lowercase form makes
+    // misconfigurations loud instead of silently passing.
+    expect(parseBearerToken('bearer abc123')).toBeNull();
+  });
+
+  it('preserves the exact token content (does not trim internal whitespace)', () => {
+    // Tokens can contain any RFC 6750 token chars; a trailing space was already
+    // stripped by the Bearer regex boundary. Leading whitespace after "Bearer "
+    // belongs to the token.
+    expect(parseBearerToken('Bearer abc 123')).toBe('abc 123');
+  });
+});
+
+describe('authenticateBearer', () => {
+  it('returns { ok: false, reason: "missing" } when no Authorization header', () => {
+    expect(authenticateBearer(undefined, callers)).toEqual({ ok: false, reason: 'missing' });
+  });
+
+  it('returns { ok: false, reason: "malformed" } for a non-Bearer header', () => {
+    expect(authenticateBearer('Basic dXNlcjpwYXNz', callers)).toEqual({ ok: false, reason: 'malformed' });
+  });
+
+  it('returns { ok: true } with the correct caller when token matches', () => {
+    const result = authenticateBearer('Bearer sk-alice-secret-0123456789abcdef', callers);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.caller.id).toBe('alice');
+      expect(result.caller.scopes).toEqual(callers.alice.scopes);
+    }
+  });
+
+  it('distinguishes between callers', () => {
+    const result = authenticateBearer('Bearer sk-bob-another-token-fedcba9876543210', callers);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.caller.id).toBe('bob');
+  });
+
+  it('returns { ok: false, reason: "invalid" } for an unknown token', () => {
+    expect(authenticateBearer('Bearer sk-unknown-12345', callers))
+      .toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  it('ignores callers with no key — they never match, even with an empty-string token', () => {
+    expect(authenticateBearer('Bearer ', callers)).toEqual({ ok: false, reason: 'malformed' });
+    // Even if parseBearerToken returned '' (it doesn't — see test above), the
+    // keyless caller would not match because we skip it outright.
+  });
+
+  it('is unaffected by token length — a short guess is not a false positive', () => {
+    // timingSafeEqual requires equal buffer sizes, so we hash both sides.
+    // A single-char guess must not accidentally match alice's key.
+    expect(authenticateBearer('Bearer a', callers).ok).toBe(false);
+    expect(authenticateBearer('Bearer sk-alice', callers).ok).toBe(false);
+  });
+
+  it('does not match when the right token is supplied with extra characters appended', () => {
+    // Defence against off-by-one comparisons
+    expect(authenticateBearer('Bearer sk-alice-secret-0123456789abcdef!', callers).ok).toBe(false);
+  });
+
+  it('handles an empty callers map by rejecting every token as invalid', () => {
+    expect(authenticateBearer('Bearer anything', {}))
+      .toEqual({ ok: false, reason: 'invalid' });
+  });
+});

--- a/packages/en-core/test/unit/rbac/resolver.test.ts
+++ b/packages/en-core/test/unit/rbac/resolver.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect } from 'vitest';
+import { resolveCaller } from '@nullproof-studio/en-core';
+import type { ResolvedConfig } from '@nullproof-studio/en-core';
+
+function baseConfig(partial: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return {
+    document_roots: {},
+    database: ':memory:',
+    transport: 'stdio',
+    port: 0,
+    search: {
+      fulltext: true,
+      sync_on_start: 'blocking',
+      batch_size: 500,
+      semantic: { enabled: false },
+    },
+    logging: { level: 'info', dir: null },
+    callers: {},
+    require_read_before_write: false,
+    ...partial,
+  };
+}
+
+describe('resolveCaller', () => {
+  it('returns a named caller when one is requested (stdio)', () => {
+    const config = baseConfig({
+      callers: {
+        alice: { scopes: [{ path: '**', permissions: ['read', 'write'] }] },
+      },
+    });
+    const result = resolveCaller(config, 'alice');
+    expect(result.id).toBe('alice');
+  });
+
+  it('auto-selects the single configured caller on stdio', () => {
+    const config = baseConfig({
+      callers: {
+        solo: { scopes: [{ path: '**', permissions: ['read'] }] },
+      },
+    });
+    const result = resolveCaller(config);
+    expect(result.id).toBe('solo');
+  });
+
+  it('falls back to _default on stdio when multiple callers exist and none is named', () => {
+    const config = baseConfig({
+      callers: {
+        alice: { scopes: [{ path: '**', permissions: ['read'] }] },
+        bob: { scopes: [{ path: '**', permissions: ['read'] }] },
+      },
+    });
+    const result = resolveCaller(config);
+    expect(result.id).toBe('_default');
+    expect(result.scopes[0].permissions).toEqual(['read', 'search']);
+  });
+
+  it('THROWS under HTTP transport when no caller is named — auto-select is unsafe there', () => {
+    const config = baseConfig({
+      transport: 'streamable-http',
+      callers: {
+        solo: { key: 'sk-solo', scopes: [{ path: '**', permissions: ['read'] }] },
+      },
+    });
+    expect(() => resolveCaller(config)).toThrow(/HTTP/);
+  });
+
+  it('still allows explicit named lookup under HTTP transport (callers can use it internally)', () => {
+    const config = baseConfig({
+      transport: 'streamable-http',
+      callers: {
+        alice: { key: 'sk-alice', scopes: [{ path: '**', permissions: ['read'] }] },
+      },
+    });
+    // Not the intended path — HTTP should go through authenticateBearer —
+    // but the named-lookup arm still works so this isn't a breaking change
+    // for any edge-case caller that already knows the ID.
+    const result = resolveCaller(config, 'alice');
+    expect(result.id).toBe('alice');
+  });
+});

--- a/packages/en-quire/src/bin.ts
+++ b/packages/en-quire/src/bin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
 import { parseArgs } from 'node:util';
-import { createServer as createHttpServer } from 'node:http';
+import { createServer as createHttpServer, type ServerResponse } from 'node:http';
 import { randomUUID } from 'node:crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -13,6 +13,7 @@ import {
   syncIndex,
   GitOperations,
   resolveCaller,
+  authenticateBearer,
   initLogger,
   getLogger,
   ToolRegistry,
@@ -90,9 +91,6 @@ async function main() {
     });
   }
 
-  // Resolve caller identity (for stdio, uses config defaults)
-  const caller = resolveCaller(config);
-
   // Sync search index per root
   for (const [name, root] of Object.entries(config.document_roots)) {
     if (config.search.sync_on_start === 'background') {
@@ -124,8 +122,12 @@ async function main() {
   }
 
   if (config.transport === 'streamable-http') {
-    await startHttpTransport(config, db, roots, caller);
+    // HTTP transport MUST NOT use the resolveCaller auto-select fallback —
+    // every request authenticates its own caller via Bearer token.
+    await startHttpTransport(config, db, roots);
   } else {
+    // stdio is inherently single-process; the startup-resolved caller is safe.
+    const caller = resolveCaller(config);
     await startStdioTransport(config, db, roots, caller);
   }
 }
@@ -150,14 +152,28 @@ async function startHttpTransport(
   config: ReturnType<typeof loadConfig>,
   db: ReturnType<typeof openDatabase>,
   roots: Record<string, RootContext>,
-  caller: ReturnType<typeof resolveCaller>,
 ) {
   const log = getLogger();
 
-  // Map of session ID → transport for stateful session management
-  const sessions = new Map<string, { server: ReturnType<typeof createServer>; transport: StreamableHTTPServerTransport }>();
+  // Map of session ID → transport, server, and the caller that was
+  // authenticated when the session was opened. Subsequent requests on the
+  // same session must present a Bearer token that resolves to the same
+  // caller — the session ID alone is NOT authentication.
+  const sessions = new Map<string, {
+    server: ReturnType<typeof createServer>;
+    transport: StreamableHTTPServerTransport;
+    callerId: string;
+  }>();
 
   const MAX_REQUEST_BODY = 10 * 1024 * 1024; // 10 MB
+
+  const unauthorized = (res: ServerResponse, reason: string) => {
+    res.writeHead(401, {
+      'Content-Type': 'application/json',
+      'WWW-Authenticate': 'Bearer realm="en-quire"',
+    });
+    res.end(JSON.stringify({ error: 'unauthorized', reason }));
+  };
 
   const httpServer = createHttpServer(async (req, res) => {
     // Reject oversized requests early
@@ -170,7 +186,8 @@ async function startHttpTransport(
 
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
 
-    // Health check endpoint
+    // Health check endpoint — intentionally unauthenticated so ops tooling
+    // can probe without a token.
     if (url.pathname === '/health' && req.method === 'GET') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ status: 'ok', sessions: sessions.size }));
@@ -183,11 +200,27 @@ async function startHttpTransport(
       return;
     }
 
+    // Every /mcp request authenticates BEFORE any session state is allocated
+    // or consulted. Missing/malformed/invalid token → 401, no session lookup.
+    const auth = authenticateBearer(req.headers.authorization, config.callers);
+    if (!auth.ok) {
+      log.debug('auth:rejected', { reason: auth.reason, path: url.pathname });
+      unauthorized(res, auth.reason);
+      return;
+    }
+
     // Handle DELETE for session termination
     if (req.method === 'DELETE') {
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
       if (sessionId && sessions.has(sessionId)) {
         const session = sessions.get(sessionId)!;
+        if (session.callerId !== auth.caller.id) {
+          log.warn('auth:session-caller-mismatch', {
+            sessionId, expected: session.callerId, got: auth.caller.id,
+          });
+          unauthorized(res, 'session_caller_mismatch');
+          return;
+        }
         await session.transport.close();
         sessions.delete(sessionId);
         log.debug('Session terminated', { sessionId });
@@ -204,8 +237,15 @@ async function startHttpTransport(
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
     if (sessionId && sessions.has(sessionId)) {
-      // Existing session
-      await sessions.get(sessionId)!.transport.handleRequest(req, res);
+      const session = sessions.get(sessionId)!;
+      if (session.callerId !== auth.caller.id) {
+        log.warn('auth:session-caller-mismatch', {
+          sessionId, expected: session.callerId, got: auth.caller.id,
+        });
+        unauthorized(res, 'session_caller_mismatch');
+        return;
+      }
+      await session.transport.handleRequest(req, res);
       return;
     }
 
@@ -216,12 +256,12 @@ async function startHttpTransport(
       return;
     }
 
-    // No session ID — create a new session (initialization request)
+    // No session ID — create a new session bound to the authenticated caller
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
     });
 
-    const server = createServer({ config, db, roots, caller });
+    const server = createServer({ config, db, roots, caller: auth.caller });
     await server.connect(transport);
 
     // Store session once we know the ID (after handleRequest processes the init)
@@ -236,8 +276,10 @@ async function startHttpTransport(
 
     // After handling the init request, the session ID is set
     if (transport.sessionId) {
-      sessions.set(transport.sessionId, { server, transport });
-      log.debug('Session created', { sessionId: transport.sessionId });
+      sessions.set(transport.sessionId, {
+        server, transport, callerId: auth.caller.id,
+      });
+      log.debug('Session created', { sessionId: transport.sessionId, caller: auth.caller.id });
     }
   });
 

--- a/packages/en-scribe/src/bin.ts
+++ b/packages/en-scribe/src/bin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
 import { parseArgs } from 'node:util';
-import { createServer as createHttpServer } from 'node:http';
+import { createServer as createHttpServer, type ServerResponse } from 'node:http';
 import { randomUUID } from 'node:crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -13,6 +13,7 @@ import {
   syncIndex,
   GitOperations,
   resolveCaller,
+  authenticateBearer,
   initLogger,
   getLogger,
   ToolRegistry,
@@ -84,8 +85,6 @@ async function main() {
     });
   }
 
-  const caller = resolveCaller(config);
-
   // Plaintext index sync — a single FTS row per file via the whole-file
   // pseudo-section. Line-chunked indexing for text_search ships later.
   for (const [name, root] of Object.entries(config.document_roots)) {
@@ -118,8 +117,11 @@ async function main() {
   }
 
   if (config.transport === 'streamable-http') {
-    await startHttpTransport(config, db, roots, caller);
+    // HTTP transport MUST NOT use the resolveCaller auto-select fallback —
+    // every request authenticates its own caller via Bearer token.
+    await startHttpTransport(config, db, roots);
   } else {
+    const caller = resolveCaller(config);
     await startStdioTransport(config, db, roots, caller);
   }
 }
@@ -144,13 +146,24 @@ async function startHttpTransport(
   config: ReturnType<typeof loadConfig>,
   db: ReturnType<typeof openDatabase>,
   roots: Record<string, RootContext>,
-  caller: ReturnType<typeof resolveCaller>,
 ) {
   const log = getLogger();
 
-  const sessions = new Map<string, { server: ReturnType<typeof createServer>; transport: StreamableHTTPServerTransport }>();
+  const sessions = new Map<string, {
+    server: ReturnType<typeof createServer>;
+    transport: StreamableHTTPServerTransport;
+    callerId: string;
+  }>();
 
   const MAX_REQUEST_BODY = 10 * 1024 * 1024;
+
+  const unauthorized = (res: ServerResponse, reason: string) => {
+    res.writeHead(401, {
+      'Content-Type': 'application/json',
+      'WWW-Authenticate': 'Bearer realm="en-scribe"',
+    });
+    res.end(JSON.stringify({ error: 'unauthorized', reason }));
+  };
 
   const httpServer = createHttpServer(async (req, res) => {
     const contentLength = parseInt(req.headers['content-length'] ?? '0', 10);
@@ -162,6 +175,7 @@ async function startHttpTransport(
 
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
 
+    // /health is intentionally unauthenticated.
     if (url.pathname === '/health' && req.method === 'GET') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ status: 'ok', sessions: sessions.size }));
@@ -174,10 +188,25 @@ async function startHttpTransport(
       return;
     }
 
+    // Bearer auth gate — runs BEFORE any session lookup or allocation.
+    const auth = authenticateBearer(req.headers.authorization, config.callers);
+    if (!auth.ok) {
+      log.debug('auth:rejected', { reason: auth.reason, path: url.pathname });
+      unauthorized(res, auth.reason);
+      return;
+    }
+
     if (req.method === 'DELETE') {
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
       if (sessionId && sessions.has(sessionId)) {
         const session = sessions.get(sessionId)!;
+        if (session.callerId !== auth.caller.id) {
+          log.warn('auth:session-caller-mismatch', {
+            sessionId, expected: session.callerId, got: auth.caller.id,
+          });
+          unauthorized(res, 'session_caller_mismatch');
+          return;
+        }
         await session.transport.close();
         sessions.delete(sessionId);
         log.debug('Session terminated', { sessionId });
@@ -193,7 +222,15 @@ async function startHttpTransport(
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
     if (sessionId && sessions.has(sessionId)) {
-      await sessions.get(sessionId)!.transport.handleRequest(req, res);
+      const session = sessions.get(sessionId)!;
+      if (session.callerId !== auth.caller.id) {
+        log.warn('auth:session-caller-mismatch', {
+          sessionId, expected: session.callerId, got: auth.caller.id,
+        });
+        unauthorized(res, 'session_caller_mismatch');
+        return;
+      }
+      await session.transport.handleRequest(req, res);
       return;
     }
 
@@ -207,7 +244,7 @@ async function startHttpTransport(
       sessionIdGenerator: () => randomUUID(),
     });
 
-    const server = createServer({ config, db, roots, caller });
+    const server = createServer({ config, db, roots, caller: auth.caller });
     await server.connect(transport);
 
     transport.onclose = () => {
@@ -220,8 +257,10 @@ async function startHttpTransport(
     await transport.handleRequest(req, res);
 
     if (transport.sessionId) {
-      sessions.set(transport.sessionId, { server, transport });
-      log.debug('Session created', { sessionId: transport.sessionId });
+      sessions.set(transport.sessionId, {
+        server, transport, callerId: auth.caller.id,
+      });
+      log.debug('Session created', { sessionId: transport.sessionId, caller: auth.caller.id });
     }
   });
 


### PR DESCRIPTION
Closes #62.

## Summary

- Adds Bearer token authentication on the `streamable-http` transport. Every `/mcp` request must carry `Authorization: Bearer <token>`; unauthenticated / malformed / invalid returns 401 before any session state is allocated.
- Sessions are now bound to the caller that authenticated them; `mcp-session-id` alone is no longer authentication. A mismatched token on a later request returns 401.
- Startup validator: HTTP transport requires every caller to have a `key` — missing keys fail loudly at startup instead of mysteriously 401'ing every request.
- Defensive: `resolveCaller()` throws when called under HTTP without an explicit caller ID. stdio path unchanged.

## Pieces

- [`en-core/rbac/http-auth.ts`](packages/en-core/src/rbac/http-auth.ts) — `parseBearerToken` + `authenticateBearer`. Constant-time compare via SHA-256 hash + `timingSafeEqual` (fixed 32-byte buffers, no length leak). Every configured caller is iterated after a match to equalise loop timing. Callers without a key are skipped outright.
- [`en-core/config/loader.ts`](packages/en-core/src/config/loader.ts) — post-parse HTTP-transport validator.
- [`en-core/rbac/resolver.ts`](packages/en-core/src/rbac/resolver.ts) — HTTP auto-select guard.
- [`en-quire/src/bin.ts`](packages/en-quire/src/bin.ts) + [`en-scribe/src/bin.ts`](packages/en-scribe/src/bin.ts) — bearer gate before session lookup, caller-bound sessions, `WWW-Authenticate: Bearer` on 401. `/health` is intentionally unauthenticated so ops tooling can still probe.

## Tests

25 new cases across 4 files:
- 16 `authenticateBearer` / `parseBearerToken` cases — scheme parsing, missing / malformed / invalid, correct-caller match, length-independence, off-by-one defence, keyless callers, empty callers
- 4 loader startup-gate cases
- 5 resolver cases covering stdio paths + HTTP guard

Full suite: **499/499 green**, lint clean.

## Test plan

- [x] Unit: `npm test` — 499/499 pass
- [x] Lint / typecheck: `npm run lint` — clean
- [ ] Manual HTTP smoke (reviewer): start server with `transport: streamable-http` + a caller with `key: "sk-test"`; verify `curl /mcp` without `Authorization` → 401, `curl /mcp -H 'Authorization: Bearer sk-test'` → session opens, `curl /mcp -H 'Authorization: Bearer wrong'` → 401
- [ ] Manual stdio smoke (reviewer): start server with `transport: stdio`; verify tool calls work as before

## Out of scope (next rung, still on #62 discussion)

Rate limiting, token rotation/revocation, audit trail of auth failures, OIDC/mTLS, multi-tenant public-internet hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)