### PR TITLE
P1 fix: safePath symlink-directory write escape (#67)

### DIFF
--- a/packages/en-core/src/shared/file-utils.ts
+++ b/packages/en-core/src/shared/file-utils.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
 import { readFileSync, writeFileSync, existsSync, statSync, readdirSync, realpathSync, lstatSync } from 'node:fs';
-import { resolve, relative, join } from 'node:path';
+import { resolve, relative, join, dirname } from 'node:path';
 import { PathTraversalError, NotFoundError } from './errors.js';
 import { decodeAndNormalise, normaliseOutbound } from './encoding.js';
 import type { EncodingInfo, LineEnding } from './types.js';
@@ -12,7 +12,12 @@ import type { EncodingInfo, LineEnding } from './types.js';
  * Security checks:
  * 1. Null byte injection — rejected outright
  * 2. Path traversal — resolved path must remain within document root
- * 3. Symlink escape — if target exists and is a symlink, its real path must be within root
+ * 3. Symlink escape — the target (or, for new files, the nearest existing
+ *    ancestor of the target) must realpath inside the root. Walking to the
+ *    nearest existing ancestor is what protects write paths: a symlinked
+ *    directory inside the root (e.g. `root/link-dir -> /etc`) would
+ *    otherwise let `root/link-dir/new-file.md` land at `/etc/new-file.md`,
+ *    because the non-existent target skips realpath entirely.
  */
 export function safePath(documentRoot: string, relativePath: string): string {
   // Reject null bytes (can bypass path checks in some environments)
@@ -27,19 +32,29 @@ export function safePath(documentRoot: string, relativePath: string): string {
     throw new PathTraversalError(relativePath);
   }
 
-  // If the target exists, resolve symlinks and verify the real path is still within root
-  if (existsSync(resolved)) {
-    try {
-      const realPath = realpathSync(resolved);
-      const realRoot = realpathSync(documentRoot);
-      const realRel = relative(realRoot, realPath);
-      if (realRel.startsWith('..')) {
-        throw new PathTraversalError(relativePath);
-      }
-    } catch (err) {
-      if (err instanceof PathTraversalError) throw err;
-      // If realpath fails for other reasons, let the downstream operation handle it
+  // Find the nearest existing ancestor — the target itself if it exists,
+  // otherwise walk up one directory at a time until we hit something.
+  // existsSync follows symlinks, so if an ancestor is a symlinked directory
+  // whose target exists, the walk stops there and realpath reveals where
+  // the write will actually land.
+  let ancestor = resolved;
+  while (!existsSync(ancestor)) {
+    const parent = dirname(ancestor);
+    if (parent === ancestor) break; // filesystem root — nothing more to climb
+    ancestor = parent;
+  }
+
+  try {
+    const realAncestor = realpathSync(ancestor);
+    const realRoot = realpathSync(documentRoot);
+    const realRel = relative(realRoot, realAncestor);
+    if (realRel.startsWith('..')) {
+      throw new PathTraversalError(relativePath);
     }
+  } catch (err) {
+    if (err instanceof PathTraversalError) throw err;
+    // realpath can fail for other reasons (EACCES, etc) — let the downstream
+    // operation surface a meaningful error rather than masking it here.
   }
 
   return resolved;

--- a/packages/en-core/test/unit/security/path-traversal.test.ts
+++ b/packages/en-core/test/unit/security/path-traversal.test.ts
@@ -62,4 +62,45 @@ describe('safePath — path traversal', () => {
     const result = safePath(docRoot, 'link.md');
     expect(result).toBe(join(docRoot, 'link.md'));
   });
+
+  // Regression tests for P1 #67 — safePath must resolve symlinks in the
+  // path's *ancestors* even when the final target itself doesn't exist yet.
+  // Otherwise a symlinked directory inside the root lets writes land at
+  // the symlink's target, outside the root.
+
+  it('rejects new file under a symlinked directory that escapes the root', () => {
+    // /docRoot/link-dir -> /outsideDir (pre-existing symlink, target exists)
+    symlinkSync(outsideDir, join(docRoot, 'link-dir'));
+
+    // Writing "link-dir/new.md" would realpath to /outsideDir/new.md,
+    // which is outside the document root.
+    expect(() => safePath(docRoot, 'link-dir/new.md')).toThrow(PathTraversalError);
+  });
+
+  it('rejects deeply nested new path whose ancestor symlink escapes the root', () => {
+    symlinkSync(outsideDir, join(docRoot, 'link-dir'));
+
+    // Even with multiple missing descendants under the symlinked ancestor,
+    // the ancestor walk must find the symlinked directory and reject.
+    expect(() => safePath(docRoot, 'link-dir/sub/deep/new.md')).toThrow(PathTraversalError);
+  });
+
+  it('allows a new file under a symlinked directory that stays within root', () => {
+    // /docRoot/real-dir exists, /docRoot/loop -> /docRoot/real-dir.
+    // Writing "loop/new.md" resolves to /docRoot/real-dir/new.md — still
+    // inside the root, so it must be allowed.
+    const realDir = join(docRoot, 'real-dir');
+    mkdirSync(realDir, { recursive: true });
+    symlinkSync(realDir, join(docRoot, 'loop'));
+
+    const result = safePath(docRoot, 'loop/new.md');
+    expect(result).toBe(join(docRoot, 'loop/new.md'));
+  });
+
+  it('allows deeply nested new paths under real directories', () => {
+    // No symlinks in the path — nested creation is a common case and
+    // must not regress.
+    const result = safePath(docRoot, 'a/b/c/new.md');
+    expect(result).toBe(join(docRoot, 'a/b/c/new.md'));
+  });
 });


### PR DESCRIPTION
Closes #67.

## Summary

P1 security fix. `safePath()` previously realpath-checked the final target only when it already existed. Every write / create / rename / edit tool calls `safePath` with a non-existent destination, so the symlink-resolution branch was skipped entirely. A pre-existing symlinked directory inside a configured root (e.g. `root/link-dir -> /etc`) let any caller with `write` permission escape the sandbox:

```
# With write permission on the root:
doc_create file="link-dir/malicious.md" content="..."
# → writes to /etc/malicious.md, outside the configured root
```

## Fix

Walk from the resolved target up to the nearest existing ancestor (whatever exists on disk, following symlinks), realpath-check that ancestor, and reject if it escapes the real root. `existsSync` follows symlinks, so the walk stops at the symlinked directory and realpath reveals where the write actually lands.

## Behaviour preserved

- Symlinks that loop back inside the root (`loop -> real-dir`) still allowed — realpath(loop) stays inside the real root.
- Deeply nested new paths under real directories still allowed.
- Existing symlinked-file escape (original P0 case) still rejected — walk stops at the file and catches the escape the same way.

## Tests

4 new regression cases in [`path-traversal.test.ts`](packages/en-core/test/unit/security/path-traversal.test.ts):

- Direct symlink-dir escape: `link-dir -> /outside`, create `link-dir/new.md` → `PathTraversalError`
- Deeply nested under symlinked ancestor: `link-dir/sub/deep/new.md` → `PathTraversalError`
- Benign loop inside root: `loop -> real-dir`, create `loop/new.md` → allowed
- Deep real-ancestor new path: `a/b/c/new.md` (no symlinks) → allowed

Plus the 7 existing `safePath` tests continue to pass. **509/509 suite green, lint clean.**

## Severity

P1 — sandbox escape. Caller still needs `write` permission in the RBAC scope, but the default `default` caller in the example config had broad `write` on `**`. Anyone with write anywhere can leverage a pre-existing symlink to write system files.

## Test plan

- [x] Unit: `npm test` — 509/509 pass
- [x] Lint / typecheck: `npm run lint` — clean
- [x] New tests fail on pre-fix code, pass after fix (verified locally during TDD)
- [ ] Manual smoke (reviewer): create a symlinked directory in a test root pointing outside, attempt `doc_create` through it, observe `PathTraversalError`

## Source

Flagged in the security review that also produced #62, #63, #68, #69. This one was marked P1 because it's an active sandbox escape rather than a posture improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)