### PR TITLE
Localhost-by-default binding + caller key strength (#68)

### DIFF
--- a/en-quire.config.example.yaml
+++ b/en-quire.config.example.yaml
@@ -43,6 +43,12 @@ require_read_before_write: true     # default: true. Set false to disable.
 transport: stdio                    # stdio | streamable-http
 port: 3100                          # Port for streamable-http transport
 
+# HTTP bind interface. Defaults to loopback so flipping to streamable-http
+# doesn't accidentally expose the server on every interface. Override to
+# "0.0.0.0" only if you intend network exposure — in that case every
+# caller MUST have a strong `key` (enforced at startup, min 32 chars).
+listen_host: "127.0.0.1"
+
 # Search configuration
 search:
   fulltext: true                    # Full-text search via SQLite FTS5 (always on)

--- a/packages/en-core/src/config/defaults.ts
+++ b/packages/en-core/src/config/defaults.ts
@@ -4,6 +4,7 @@ import type { ResolvedConfig } from '../shared/types.js';
 export const DEFAULT_CONFIG: Omit<ResolvedConfig, 'document_roots' | 'database'> = {
   transport: 'stdio',
   port: 3100,
+  listen_host: '127.0.0.1',
   search: {
     fulltext: true,
     sync_on_start: 'blocking',

--- a/packages/en-core/src/config/loader.ts
+++ b/packages/en-core/src/config/loader.ts
@@ -58,6 +58,42 @@ export function loadConfig(configPath: string): ResolvedConfig {
         `Missing keys for caller(s): ${missing.join(', ')}.`,
       );
     }
+
+    // Minimum key strength — reject obvious test/placeholder values that
+    // would otherwise pass the "non-empty string" check. 32 chars isn't a
+    // cryptographic guarantee, but it rules out "x", "secret", "changeme"
+    // and the like, which is the class of misconfiguration this catches.
+    const MIN_KEY_LENGTH = 32;
+    const tooShort = Object.entries(validated.callers)
+      .filter(([, caller]) => caller.key && caller.key.length < MIN_KEY_LENGTH)
+      .map(([id, caller]) => `${id} (${caller.key?.length ?? 0} chars)`);
+    if (tooShort.length > 0) {
+      throw new ValidationError(
+        `HTTP transport requires caller keys to be at least ${MIN_KEY_LENGTH} characters. ` +
+        `Weak keys: ${tooShort.join(', ')}. Use crypto.randomBytes(24).toString('base64') ` +
+        `or similar to generate tokens.`,
+      );
+    }
+
+    // Reject obvious placeholder values even if they meet the length bar —
+    // padding "changeme" to 32 chars is a user error, not a legitimate key.
+    const placeholderPatterns = [
+      /^change[_-]?me/i,
+      /^placeholder/i,
+      /^test[_-]?token/i,
+      /^secret$/i,
+      /^token$/i,
+      /^(.)\1+$/, // all the same character
+    ];
+    const placeholder = Object.entries(validated.callers)
+      .filter(([, caller]) => caller.key && placeholderPatterns.some((p) => p.test(caller.key!)))
+      .map(([id]) => id);
+    if (placeholder.length > 0) {
+      throw new ValidationError(
+        `HTTP transport: caller key(s) look like placeholder values: ${placeholder.join(', ')}. ` +
+        `Generate real tokens before enabling HTTP transport.`,
+      );
+    }
   }
 
   // Resolve document roots
@@ -86,6 +122,7 @@ export function loadConfig(configPath: string): ResolvedConfig {
     database,
     transport: validated.transport,
     port: validated.port,
+    listen_host: validated.listen_host,
     search: {
       fulltext: validated.search.fulltext,
       sync_on_start: validated.search.sync_on_start,

--- a/packages/en-core/src/config/schema.ts
+++ b/packages/en-core/src/config/schema.ts
@@ -56,6 +56,11 @@ export const ConfigSchema = z.object({
   database: z.string().optional(), // Path to .enquire.db; defaults to next to config file
   transport: z.enum(['stdio', 'streamable-http']).default('stdio'),
   port: z.number().int().positive().default(3100),
+  // Interface to bind the HTTP server to. Defaults to loopback so an
+  // operator who flips `transport: streamable-http` doesn't accidentally
+  // serve on a LAN. Set to "0.0.0.0" only if you intend network exposure —
+  // Bearer auth is required in that case (enforced at startup).
+  listen_host: z.string().default('127.0.0.1'),
   search: SearchSchema.default({}),
   logging: LoggingSchema.default({}),
   callers: z.record(z.string(), CallerConfigSchema).default({}),

--- a/packages/en-core/src/shared/types.ts
+++ b/packages/en-core/src/shared/types.ts
@@ -167,6 +167,7 @@ export interface ResolvedConfig {
   database: string; // absolute path to .enquire.db
   transport: 'stdio' | 'streamable-http';
   port: number;
+  listen_host: string; // Interface to bind the HTTP server to (default 127.0.0.1)
   search: {
     fulltext: boolean;
     sync_on_start: 'blocking' | 'background';

--- a/packages/en-core/test/unit/config/http-auth-validation.test.ts
+++ b/packages/en-core/test/unit/config/http-auth-validation.test.ts
@@ -21,6 +21,11 @@ function writeConfig(yaml: string): string {
   return path;
 }
 
+// 32+ char placeholder tokens for the "valid config" tests. Intentionally
+// look random-ish so they pass the strength + placeholder checks.
+const STRONG_ALICE = 'sk-alice-a1B2c3D4e5F6g7H8i9J0kLmNoPqR';
+const STRONG_BOB = 'sk-bob-Z9y8x7w6V5u4T3s2R1q0pOnMlK';
+
 describe('loadConfig — HTTP transport caller-key validation', () => {
   it('throws when HTTP transport is configured and any caller lacks a key', () => {
     const path = writeConfig(`
@@ -30,7 +35,7 @@ document_roots:
 transport: streamable-http
 callers:
   alice:
-    key: sk-alice-valid
+    key: ${STRONG_ALICE}
     scopes:
       - path: "**"
         permissions: [read]
@@ -44,7 +49,7 @@ callers:
     expect(() => loadConfig(path)).toThrow(/bob/);
   });
 
-  it('passes when HTTP transport is configured and every caller has a key', () => {
+  it('passes when HTTP transport is configured and every caller has a strong key', () => {
     const path = writeConfig(`
 document_roots:
   notes:
@@ -52,12 +57,12 @@ document_roots:
 transport: streamable-http
 callers:
   alice:
-    key: sk-alice-valid
+    key: ${STRONG_ALICE}
     scopes:
       - path: "**"
         permissions: [read]
   bob:
-    key: sk-bob-valid
+    key: ${STRONG_BOB}
     scopes:
       - path: "**"
         permissions: [read]
@@ -96,5 +101,101 @@ document_roots:
 transport: streamable-http
 `);
     expect(() => loadConfig(path)).not.toThrow();
+  });
+});
+
+describe('loadConfig — HTTP transport caller-key STRENGTH validation', () => {
+  it('rejects keys shorter than 32 characters under HTTP transport', () => {
+    const path = writeConfig(`
+document_roots:
+  notes:
+    path: .
+transport: streamable-http
+callers:
+  alice:
+    key: too-short
+    scopes:
+      - path: "**"
+        permissions: [read]
+`);
+    expect(() => loadConfig(path)).toThrow(/at least 32/i);
+    expect(() => loadConfig(path)).toThrow(/alice/);
+  });
+
+  it('rejects placeholder keys even when the length is sufficient', () => {
+    // 36 chars of "changeme", so length passes but pattern catches it
+    const path = writeConfig(`
+document_roots:
+  notes:
+    path: .
+transport: streamable-http
+callers:
+  alice:
+    key: changeme-changeme-changeme-changeme
+    scopes:
+      - path: "**"
+        permissions: [read]
+`);
+    expect(() => loadConfig(path)).toThrow(/placeholder/i);
+  });
+
+  it('rejects repeated-character keys (looks like a stand-in)', () => {
+    const path = writeConfig(`
+document_roots:
+  notes:
+    path: .
+transport: streamable-http
+callers:
+  alice:
+    key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    scopes:
+      - path: "**"
+        permissions: [read]
+`);
+    expect(() => loadConfig(path)).toThrow(/placeholder/i);
+  });
+
+  it('does not enforce key strength under stdio transport', () => {
+    // stdio callers don't use bearer auth, so weak-looking keys should pass.
+    // The key field may still be set for other purposes (caller ID display,
+    // future cross-transport tooling), and stdio validation shouldn't care.
+    const path = writeConfig(`
+document_roots:
+  notes:
+    path: .
+transport: stdio
+callers:
+  alice:
+    key: changeme
+    scopes:
+      - path: "**"
+        permissions: [read]
+`);
+    expect(() => loadConfig(path)).not.toThrow();
+  });
+});
+
+describe('loadConfig — listen_host', () => {
+  it('defaults to 127.0.0.1 when not specified', () => {
+    const path = writeConfig(`
+document_roots:
+  notes:
+    path: .
+transport: stdio
+`);
+    const config = loadConfig(path);
+    expect(config.listen_host).toBe('127.0.0.1');
+  });
+
+  it('accepts an explicit override', () => {
+    const path = writeConfig(`
+document_roots:
+  notes:
+    path: .
+transport: stdio
+listen_host: "0.0.0.0"
+`);
+    const config = loadConfig(path);
+    expect(config.listen_host).toBe('0.0.0.0');
   });
 });

--- a/packages/en-quire/src/bin.ts
+++ b/packages/en-quire/src/bin.ts
@@ -289,12 +289,18 @@ async function startHttpTransport(
   httpServer.requestTimeout = 120000; // 2min total request timeout
 
   const port = config.port;
-  httpServer.listen(port, () => {
+  const host = config.listen_host;
+  httpServer.listen(port, host, () => {
     log.info('Server listening', {
       transport: 'streamable-http',
+      host,
       port,
       roots: Object.keys(config.document_roots),
     });
+    if (host === '0.0.0.0') {
+      log.warn('HTTP server bound to 0.0.0.0 — exposed on every interface. ' +
+        'Confirm this is intentional and that caller keys are strong.');
+    }
   });
 
   // Graceful shutdown

--- a/packages/en-scribe/src/bin.ts
+++ b/packages/en-scribe/src/bin.ts
@@ -269,12 +269,18 @@ async function startHttpTransport(
   httpServer.requestTimeout = 120000;
 
   const port = config.port;
-  httpServer.listen(port, () => {
+  const host = config.listen_host;
+  httpServer.listen(port, host, () => {
     log.info('Server listening', {
       transport: 'streamable-http',
+      host,
       port,
       roots: Object.keys(config.document_roots),
     });
+    if (host === '0.0.0.0') {
+      log.warn('HTTP server bound to 0.0.0.0 — exposed on every interface. ' +
+        'Confirm this is intentional and that caller keys are strong.');
+    }
   });
 
   const shutdown = async () => {


### PR DESCRIPTION
Closes #68.

## Summary

Two startup-time guards against operator misconfiguration on the `streamable-http` transport. Both are posture improvements, not bug fixes — the bearer-auth gate from #62 still catches unauthenticated traffic. These close the class of misconfiguration where a well-meaning operator thinks they've done enough.

## 1. Bind to 127.0.0.1 by default

Before: `httpServer.listen(port)` → Node defaults to `0.0.0.0` → server on every interface from the moment `transport: streamable-http` is set.

After:

- New config field `listen_host: string`, default `"127.0.0.1"`.
- Both bins pass it to `httpServer.listen(port, host, cb)`.
- Explicit warning logged on startup when bound to `0.0.0.0`.
- Example config documents the field and the escalation path.

## 2. Caller key strength validation under HTTP transport

Before: `key: "x"` passed the missing-key check from #62.

After:

- Reject under HTTP transport if any caller's key is shorter than 32 chars.
- Reject under HTTP transport if any caller's key matches common placeholder patterns (`changeme*`, `placeholder*`, `test-token*`, `secret`, `token`, all-same-character).
- Clear error message with an actionable fix suggestion.
- stdio transport unchanged — keys there may exist for other tooling reasons and the bearer gate doesn't apply.

## What this doesn't do

- Token rotation / revocation (separate issue)
- Rate limiting (reverse proxy)
- Audit logging of auth failures (separate issue)

## Tests

7 new cases:

- listen_host: default + override (2)
- key strength: too short / placeholder / all-same-char / stdio unaffected (4)
- Updated the existing "every caller has a key" fixture to use 32+ char keys so it exercises both checks

**515/515 suite green, lint clean.**

## Test plan

- [x] Unit: `npm test` — 515/515 pass
- [x] Lint / typecheck: `npm run lint` — clean
- [ ] Manual smoke (reviewer): config with `transport: streamable-http` + `key: "x"` fails loudly at startup with a clear message; config with `listen_host: 0.0.0.0` warns on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)