### PR TITLE
HTTP transport: end-to-end auth integration tests (#69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,21 @@ jobs:
       - run: npm ci
       - run: npm test
 
+  test-integration:
+    name: Test (integration)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      # en-core dist is required — integration tests import from
+      # packages/en-quire/src, which uses @nullproof-studio/en-core at runtime.
+      - run: npm run build -w @nullproof-studio/en-core
+      - run: npm run test:integration
+
   publish-dryrun:
     name: Publish dry-run
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "build": "npm run build -w @nullproof-studio/en-core && npm run build -w @nullproof-studio/en-quire && npm run build -w @nullproof-studio/en-scribe",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:all": "npm run test && npm run test:integration",
     "lint": "tsc --noEmit -p packages/en-core && tsc --noEmit -p packages/en-quire && tsc --noEmit -p packages/en-scribe",
     "clean": "npm run clean -w @nullproof-studio/en-core --if-present && npm run clean -w @nullproof-studio/en-quire --if-present && npm run clean -w @nullproof-studio/en-scribe --if-present"
   },

--- a/packages/en-quire/src/bin.ts
+++ b/packages/en-quire/src/bin.ts
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
 // Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
 import { parseArgs } from 'node:util';
-import { createServer as createHttpServer, type ServerResponse } from 'node:http';
-import { randomUUID } from 'node:crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type Database from 'better-sqlite3';
 import {
   loadConfig,
@@ -13,7 +10,6 @@ import {
   syncIndex,
   GitOperations,
   resolveCaller,
-  authenticateBearer,
   initLogger,
   getLogger,
   ToolRegistry,
@@ -30,6 +26,7 @@ import './parsers/markdown-parser.js';
 import './parsers/yaml-parser.js';
 import './parsers/jsonl-parser.js';
 import { registerEnQuireTools } from './plugin.js';
+import { createMcpHttpServer } from './http-server.js';
 
 interface ServerDependencies {
   config: ResolvedConfig;
@@ -155,138 +152,11 @@ async function startHttpTransport(
 ) {
   const log = getLogger();
 
-  // Map of session ID → transport, server, and the caller that was
-  // authenticated when the session was opened. Subsequent requests on the
-  // same session must present a Bearer token that resolves to the same
-  // caller — the session ID alone is NOT authentication.
-  const sessions = new Map<string, {
-    server: ReturnType<typeof createServer>;
-    transport: StreamableHTTPServerTransport;
-    callerId: string;
-  }>();
-
-  const MAX_REQUEST_BODY = 10 * 1024 * 1024; // 10 MB
-
-  const unauthorized = (res: ServerResponse, reason: string) => {
-    res.writeHead(401, {
-      'Content-Type': 'application/json',
-      'WWW-Authenticate': 'Bearer realm="en-quire"',
-    });
-    res.end(JSON.stringify({ error: 'unauthorized', reason }));
-  };
-
-  const httpServer = createHttpServer(async (req, res) => {
-    // Reject oversized requests early
-    const contentLength = parseInt(req.headers['content-length'] ?? '0', 10);
-    if (contentLength > MAX_REQUEST_BODY) {
-      res.writeHead(413, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Request body too large. Maximum 10 MB.' }));
-      return;
-    }
-
-    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
-
-    // Health check endpoint — intentionally unauthenticated so ops tooling
-    // can probe without a token.
-    if (url.pathname === '/health' && req.method === 'GET') {
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ status: 'ok', sessions: sessions.size }));
-      return;
-    }
-
-    if (url.pathname !== '/mcp') {
-      res.writeHead(404, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Not found. Use /mcp or /health endpoints.' }));
-      return;
-    }
-
-    // Every /mcp request authenticates BEFORE any session state is allocated
-    // or consulted. Missing/malformed/invalid token → 401, no session lookup.
-    const auth = authenticateBearer(req.headers.authorization, config.callers);
-    if (!auth.ok) {
-      log.debug('auth:rejected', { reason: auth.reason, path: url.pathname });
-      unauthorized(res, auth.reason);
-      return;
-    }
-
-    // Handle DELETE for session termination
-    if (req.method === 'DELETE') {
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
-      if (sessionId && sessions.has(sessionId)) {
-        const session = sessions.get(sessionId)!;
-        if (session.callerId !== auth.caller.id) {
-          log.warn('auth:session-caller-mismatch', {
-            sessionId, expected: session.callerId, got: auth.caller.id,
-          });
-          unauthorized(res, 'session_caller_mismatch');
-          return;
-        }
-        await session.transport.close();
-        sessions.delete(sessionId);
-        log.debug('Session terminated', { sessionId });
-        res.writeHead(200);
-        res.end();
-      } else {
-        res.writeHead(404, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Session not found' }));
-      }
-      return;
-    }
-
-    // For GET and POST, route to existing session or create new one
-    const sessionId = req.headers['mcp-session-id'] as string | undefined;
-
-    if (sessionId && sessions.has(sessionId)) {
-      const session = sessions.get(sessionId)!;
-      if (session.callerId !== auth.caller.id) {
-        log.warn('auth:session-caller-mismatch', {
-          sessionId, expected: session.callerId, got: auth.caller.id,
-        });
-        unauthorized(res, 'session_caller_mismatch');
-        return;
-      }
-      await session.transport.handleRequest(req, res);
-      return;
-    }
-
-    if (sessionId && !sessions.has(sessionId)) {
-      // Invalid session ID
-      res.writeHead(404, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Session not found' }));
-      return;
-    }
-
-    // No session ID — create a new session bound to the authenticated caller
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-    });
-
-    const server = createServer({ config, db, roots, caller: auth.caller });
-    await server.connect(transport);
-
-    // Store session once we know the ID (after handleRequest processes the init)
-    transport.onclose = () => {
-      if (transport.sessionId) {
-        sessions.delete(transport.sessionId);
-        log.debug('Session closed', { sessionId: transport.sessionId });
-      }
-    };
-
-    await transport.handleRequest(req, res);
-
-    // After handling the init request, the session ID is set
-    if (transport.sessionId) {
-      sessions.set(transport.sessionId, {
-        server, transport, callerId: auth.caller.id,
-      });
-      log.debug('Session created', { sessionId: transport.sessionId, caller: auth.caller.id });
-    }
+  const { httpServer, sessions } = createMcpHttpServer({
+    config, db, roots,
+    createMcpServer: (deps) => createServer(deps),
+    realm: 'en-quire',
   });
-
-  // Harden HTTP server defaults
-  httpServer.maxHeadersCount = 50;
-  httpServer.headersTimeout = 20000; // 20s to send headers
-  httpServer.requestTimeout = 120000; // 2min total request timeout
 
   const port = config.port;
   httpServer.listen(port, () => {

--- a/packages/en-quire/src/http-server.ts
+++ b/packages/en-quire/src/http-server.ts
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { createServer as createHttpServer, type ServerResponse, type Server as HttpServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type Database from 'better-sqlite3';
+import {
+  authenticateBearer,
+  getLogger,
+} from '@nullproof-studio/en-core';
+import type {
+  ResolvedConfig,
+  CallerIdentity,
+  RootContext,
+} from '@nullproof-studio/en-core';
+
+/**
+ * Factory that builds the HTTP request handler for the MCP streamable-http
+ * transport, wired to Bearer auth + per-session caller binding. Exported so
+ * integration tests can exercise the same handler bin.ts uses without having
+ * to spawn the full bin as a subprocess.
+ *
+ * Caller supplies `createMcpServer` — the factory that builds an McpServer
+ * with the right tool registry + format parsers for the binary (en-quire
+ * registers markdown/yaml/jsonl, en-scribe registers plain-text).
+ */
+export interface CreateHttpServerOptions {
+  config: ResolvedConfig;
+  db: Database.Database;
+  roots: Record<string, RootContext>;
+  createMcpServer: (deps: {
+    config: ResolvedConfig;
+    db: Database.Database;
+    roots: Record<string, RootContext>;
+    caller: CallerIdentity;
+  }) => McpServer;
+  realm: string; // for WWW-Authenticate, e.g. "en-quire"
+}
+
+export interface McpHttpServerHandle {
+  /** The http.Server, NOT yet listening. Caller calls listen() and close(). */
+  httpServer: HttpServer;
+  /** Session map — exposed for integration test assertions. */
+  sessions: Map<string, {
+    server: McpServer;
+    transport: StreamableHTTPServerTransport;
+    callerId: string;
+  }>;
+}
+
+const MAX_REQUEST_BODY = 10 * 1024 * 1024; // 10 MB
+
+export function createMcpHttpServer(options: CreateHttpServerOptions): McpHttpServerHandle {
+  const { config, db, roots, createMcpServer, realm } = options;
+  const log = getLogger();
+
+  const sessions = new Map<string, {
+    server: McpServer;
+    transport: StreamableHTTPServerTransport;
+    callerId: string;
+  }>();
+
+  const unauthorized = (res: ServerResponse, reason: string) => {
+    res.writeHead(401, {
+      'Content-Type': 'application/json',
+      'WWW-Authenticate': `Bearer realm="${realm}"`,
+    });
+    res.end(JSON.stringify({ error: 'unauthorized', reason }));
+  };
+
+  const httpServer = createHttpServer(async (req, res) => {
+    const contentLength = parseInt(req.headers['content-length'] ?? '0', 10);
+    if (contentLength > MAX_REQUEST_BODY) {
+      res.writeHead(413, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Request body too large. Maximum 10 MB.' }));
+      return;
+    }
+
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+
+    if (url.pathname === '/health' && req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', sessions: sessions.size }));
+      return;
+    }
+
+    if (url.pathname !== '/mcp') {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found. Use /mcp or /health endpoints.' }));
+      return;
+    }
+
+    const auth = authenticateBearer(req.headers.authorization, config.callers);
+    if (!auth.ok) {
+      log.debug('auth:rejected', { reason: auth.reason, path: url.pathname });
+      unauthorized(res, auth.reason);
+      return;
+    }
+
+    if (req.method === 'DELETE') {
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+      if (sessionId && sessions.has(sessionId)) {
+        const session = sessions.get(sessionId)!;
+        if (session.callerId !== auth.caller.id) {
+          log.warn('auth:session-caller-mismatch', {
+            sessionId, expected: session.callerId, got: auth.caller.id,
+          });
+          unauthorized(res, 'session_caller_mismatch');
+          return;
+        }
+        await session.transport.close();
+        sessions.delete(sessionId);
+        log.debug('Session terminated', { sessionId });
+        res.writeHead(200);
+        res.end();
+      } else {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Session not found' }));
+      }
+      return;
+    }
+
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+    if (sessionId && sessions.has(sessionId)) {
+      const session = sessions.get(sessionId)!;
+      if (session.callerId !== auth.caller.id) {
+        log.warn('auth:session-caller-mismatch', {
+          sessionId, expected: session.callerId, got: auth.caller.id,
+        });
+        unauthorized(res, 'session_caller_mismatch');
+        return;
+      }
+      await session.transport.handleRequest(req, res);
+      return;
+    }
+
+    if (sessionId && !sessions.has(sessionId)) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Session not found' }));
+      return;
+    }
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+    });
+
+    const server = createMcpServer({ config, db, roots, caller: auth.caller });
+    await server.connect(transport);
+
+    transport.onclose = () => {
+      if (transport.sessionId) {
+        sessions.delete(transport.sessionId);
+        log.debug('Session closed', { sessionId: transport.sessionId });
+      }
+    };
+
+    await transport.handleRequest(req, res);
+
+    if (transport.sessionId) {
+      sessions.set(transport.sessionId, {
+        server, transport, callerId: auth.caller.id,
+      });
+      log.debug('Session created', { sessionId: transport.sessionId, caller: auth.caller.id });
+    }
+  });
+
+  httpServer.maxHeadersCount = 50;
+  httpServer.headersTimeout = 20000;
+  httpServer.requestTimeout = 120000;
+
+  return { httpServer, sessions };
+}

--- a/packages/en-quire/test/integration/http-auth.test.ts
+++ b/packages/en-quire/test/integration/http-auth.test.ts
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AddressInfo } from 'node:net';
+import Database from 'better-sqlite3';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  initSearchSchema,
+  GitOperations,
+  ToolRegistry,
+  attachRegistry,
+  initLogger,
+} from '@nullproof-studio/en-core';
+import type {
+  ResolvedConfig,
+  RootContext,
+  CallerIdentity,
+  ToolContext,
+} from '@nullproof-studio/en-core';
+import { createMcpHttpServer } from '../../src/http-server.js';
+
+/**
+ * End-to-end tests for the HTTP transport's auth wiring (#69). These start
+ * a real `http.Server` on port 0, bound to loopback, and exercise the five
+ * scenarios the unit tests can't prove:
+ *
+ *   1. Unauthenticated /mcp → 401, WWW-Authenticate header, no session
+ *   2. Wrong token → 401
+ *   3. Valid token → initialize handshake succeeds, session created
+ *   4. Swapped-token-on-same-session → 401 session_caller_mismatch
+ *   5. /health remains unauthenticated
+ *
+ * The whole stack is imported, not spawned, so failures show real stack
+ * traces. The MCP server factory uses a minimal empty tool registry —
+ * we're testing auth wiring, not tool behaviour.
+ */
+
+const STRONG_TOKEN_ALICE = 'sk-alice-a1B2c3D4e5F6g7H8i9J0kLmNoPqR';
+const STRONG_TOKEN_BOB = 'sk-bob-Z9y8x7w6V5u4T3s2R1q0pOnMlKjIhG';
+
+function makeConfig(rootDir: string): ResolvedConfig {
+  return {
+    document_roots: {
+      notes: {
+        name: 'notes',
+        path: rootDir,
+        git: { enabled: false, auto_commit: false, remote: null, pr_hook: null },
+      },
+    },
+    database: ':memory:',
+    transport: 'streamable-http',
+    port: 0,
+    listen_host: '127.0.0.1',
+    search: { fulltext: false, sync_on_start: 'blocking', batch_size: 100, semantic: { enabled: false } },
+    logging: { level: 'error', dir: null },
+    callers: {
+      alice: {
+        key: STRONG_TOKEN_ALICE,
+        scopes: [{ path: '**', permissions: ['read'] }],
+      },
+      bob: {
+        key: STRONG_TOKEN_BOB,
+        scopes: [{ path: '**', permissions: ['read'] }],
+      },
+    },
+    require_read_before_write: false,
+  };
+}
+
+function makeMcpServer(deps: { config: ResolvedConfig; db: Database.Database; roots: Record<string, RootContext>; caller: CallerIdentity }): McpServer {
+  const server = new McpServer({ name: 'en-quire-test', version: '0.0.0' });
+  const ctx: ToolContext = { config: deps.config, roots: deps.roots, caller: deps.caller, db: deps.db };
+  const registry = new ToolRegistry();
+  attachRegistry(server, registry, ctx);
+  return server;
+}
+
+let rootDir: string;
+let db: Database.Database;
+let baseUrl: string;
+let httpServer: Awaited<ReturnType<typeof createMcpHttpServer>>['httpServer'];
+let sessions: Awaited<ReturnType<typeof createMcpHttpServer>>['sessions'];
+
+beforeEach(async () => {
+  initLogger({ level: 'error', dir: null }, 'en-quire');
+  rootDir = mkdtempSync(join(tmpdir(), 'http-auth-integration-'));
+  db = new Database(':memory:');
+  initSearchSchema(db);
+
+  const config = makeConfig(rootDir);
+  const roots: Record<string, RootContext> = {
+    notes: {
+      root: config.document_roots.notes,
+      git: new GitOperations(rootDir, false),
+    },
+  };
+
+  const built = createMcpHttpServer({
+    config, db, roots,
+    createMcpServer: makeMcpServer,
+    realm: 'en-quire',
+  });
+  httpServer = built.httpServer;
+  sessions = built.sessions;
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = httpServer.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  db.close();
+  rmSync(rootDir, { recursive: true, force: true });
+});
+
+describe('HTTP transport — auth wiring (integration)', () => {
+  it('rejects /mcp without Authorization with 401 and WWW-Authenticate', async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json, text/event-stream' },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 1, method: 'initialize',
+        params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '0' } },
+      }),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get('WWW-Authenticate')).toContain('Bearer');
+    const body = await res.json() as { error: string; reason: string };
+    expect(body.error).toBe('unauthorized');
+    expect(body.reason).toBe('missing');
+
+    // No session should have been allocated
+    expect(sessions.size).toBe(0);
+  });
+
+  it('rejects /mcp with a wrong token — same 401 shape', async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer sk-wrong-4444444444444444444444444444444',
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 1, method: 'initialize',
+        params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '0' } },
+      }),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json() as { reason: string };
+    expect(body.reason).toBe('invalid');
+    expect(sessions.size).toBe(0);
+  });
+
+  it('accepts /mcp with a valid token and creates a caller-bound session', async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${STRONG_TOKEN_ALICE}`,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 1, method: 'initialize',
+        params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '0' } },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const sessionId = res.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+    expect(sessions.size).toBe(1);
+    expect(sessions.get(sessionId!)?.callerId).toBe('alice');
+  });
+
+  it('rejects a request that reuses a session ID but swaps the token', async () => {
+    // Open a session as alice
+    const initRes = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${STRONG_TOKEN_ALICE}`,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 1, method: 'initialize',
+        params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '0' } },
+      }),
+    });
+    expect(initRes.status).toBe(200);
+    const sessionId = initRes.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+
+    // Now reuse the session with bob's token — must be rejected
+    const hijackRes = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${STRONG_TOKEN_BOB}`,
+        'mcp-session-id': sessionId!,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 2, method: 'tools/list', params: {},
+      }),
+    });
+    expect(hijackRes.status).toBe(401);
+    const body = await hijackRes.json() as { reason: string };
+    expect(body.reason).toBe('session_caller_mismatch');
+
+    // Original session is still intact — not destroyed by the hijack attempt
+    expect(sessions.get(sessionId!)?.callerId).toBe('alice');
+  });
+
+  it('serves /health without authentication', async () => {
+    const res = await fetch(`${baseUrl}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { status: string; sessions: number };
+    expect(body.status).toBe('ok');
+    expect(body.sessions).toBe(0);
+  });
+
+  it('rejects /health with authentication still passes (auth not required but not rejected)', async () => {
+    // Minor regression guard: having Authorization on /health shouldn't 4xx.
+    const res = await fetch(`${baseUrl}/health`, {
+      headers: { 'Authorization': `Bearer ${STRONG_TOKEN_ALICE}` },
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
     globals: true,
     testTimeout: 10000,
     include: ['packages/*/test/**/*.test.ts'],
+    // Integration tests (real HTTP servers, real git remotes) live under
+    // `test/integration/` in any package. They are opted into via
+    // `npm run test:integration` rather than running on every `npm test`.
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/test/integration/**',
+    ],
     alias: {
       '@nullproof-studio/en-core': resolve(__dirname, 'packages/en-core/src/index.ts'),
     },

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+/**
+ * Integration tests — real HTTP servers, real git remotes, anything that
+ * takes noticeably longer than a unit test. Runs via `npm run test:integration`.
+ * Keeps the default `npm test` path focused on fast unit coverage.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 30000,
+    include: ['packages/*/test/integration/**/*.test.ts'],
+    alias: {
+      '@nullproof-studio/en-core': resolve(__dirname, 'packages/en-core/src/index.ts'),
+    },
+  },
+});


### PR DESCRIPTION
Closes #69.

## Summary

#62 shipped bearer-token auth with 25 unit tests. Those prove the primitives. This PR lands the missing layer: real HTTP server, real `fetch()`, real JSON-RPC init handshakes — catches the wiring-regression class where a future refactor could bypass the gate on the new-session path, drop the \`WWW-Authenticate\` header, or accidentally auth \`/health\`.

## Structural change

Extracted the HTTP server setup from [`bin.ts`](packages/en-quire/src/bin.ts) into a new [\`http-server.ts\`](packages/en-quire/src/http-server.ts) module exporting \`createMcpHttpServer\`. \`bin.ts\` becomes a thin wrapper that calls \`listen()\` + wires \`SIGTERM\`. Integration tests import the exact same factory — no shadow implementation that could drift from what ships.

## Test coverage

6 cases in [\`test/integration/http-auth.test.ts\`](packages/en-quire/test/integration/http-auth.test.ts):

1. **Unauthenticated \`/mcp\`** → 401 + \`WWW-Authenticate: Bearer\` + no session state
2. **Wrong token** → 401 \`reason=invalid\`
3. **Valid token** → \`initialize\` succeeds, session bound to caller
4. **Swapped token on same session** → 401 \`reason=session_caller_mismatch\`, original session untouched
5. **\`/health\` unauthenticated** → 200 without Authorization
6. **\`/health\` tolerates Authorization** (regression guard)

Each opens a loopback server on port 0 in \`beforeEach\`, closes in \`afterEach\`. Total runtime ~400ms for 6 cases.

## Ops plumbing

- New \`npm run test:integration\` (via [\`vitest.integration.config.ts\`](vitest.integration.config.ts)) includes only \`**/test/integration/**\`.
- Default \`npm test\` and \`vitest.config.ts\` **exclude** integration so the unit loop stays fast.
- \`npm run test:all\` runs both.
- CI gains a separate \`test-integration\` job alongside the existing \`test\` job in [.github/workflows/ci.yml](.github/workflows/ci.yml); both must pass for PRs.

## Test plan

- [x] Unit: \`npm test\` → 509/509 pass (integration excluded)
- [x] Integration: \`npm run test:integration\` → 6/6 pass (~400ms)
- [x] Lint / typecheck: \`npm run lint\` → clean
- [x] Combined: \`npm run test:all\` runs both cleanly

## Not done

- en-scribe equivalent. The bin's HTTP handler is near-identical to en-quire's — a future refactor could extract a shared en-core implementation. Not in scope for this PR (#69 explicitly targeted the wiring coverage, not a cross-bin dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)