### PR TITLE
Git integration v0.2 (governance + PoC) — DRAFT, local soak in progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ docs/session-memory/
 en-quire-repo-setup.md
 en-quire-spec.md
 .mcp.json
+
+spec-local/

--- a/README.md
+++ b/README.md
@@ -176,15 +176,29 @@ doc_replace_section({
   content: "\nAdded new environment check for API keys.\n",
   mode: "propose"
 })
-→ { success: true, mode: "propose", branch: "propose/michelle/sops/deployment/20260317T1423Z" }
+→ { success: true, mode: "propose", branch: "propose/michelle/sops/deployment.md/20260317T1423Z" }
 ```
 
-An approver can then review and merge:
+An approver can review and merge through the MCP:
 
 ```
-doc_proposal_diff({ branch: "propose/michelle/sops/deployment/20260317T1423Z" })
-doc_proposal_approve({ branch: "propose/michelle/sops/deployment/20260317T1423Z" })
+doc_proposal_diff({ branch: "propose/michelle/sops/deployment.md/20260317T1423Z" })
+doc_proposal_approve({ branch: "propose/michelle/sops/deployment.md/20260317T1423Z" })
 ```
+
+Or on GitHub/GitLab — when `git.remote` + `git.push_proposals` + `git.pr_hook` are configured on a root, every propose write also pushes the branch and fires the hook (typically `gh pr create ...`) so the proposal shows up as a real PR:
+
+```yaml
+document_roots:
+  docs:
+    path: /data/docs
+    git:
+      remote: origin
+      push_proposals: true
+      pr_hook: "gh pr create --head {branch} --title 'Proposal: {file}' --base main"
+```
+
+`doc_proposal_approve` pre-flight-fetches the remote before merging and refuses if the branch is gone (likely already merged upstream), preventing divergent local history. `doc_proposals_list` stays current across sessions via a startup `git fetch --prune`.
 
 ### 7. Work with YAML files
 
@@ -389,7 +403,8 @@ curl http://localhost:3100/health
 ## Roadmap
 
 - **v0.1 — Core**: Document parsing, section addressing, read/write tools, git integration, full-text search, basic RBAC, Docker image, stdio transport, streamable-http transport.
-- **v0.2 — Governance**: Proposal workflows, remote push, PR hooks, audit log queries, conflict detection.
+- **v0.2 — Governance** (shipped): Proposal workflows, remote push (`git.push_proposals`), PR hooks (`git.pr_hook`), safe approve with pre-flight fetch, commit-metadata hydration, startup fetch-prune reconciliation, HTTP bearer-token auth + session-bound callers, localhost-default binding, authorization correctness fixes (rename destination scope, file-scoped approve/reject, branch-validated reject), symlink-ancestor realpath check.
+- **v0.2 — remaining**: Audit log queries, conflict detection (`can_merge` / `conflicts[]`).
 - **v0.3 — Search & Intelligence**: Semantic vector search, cross-document reference tracking, inverse lookups, context bundle builder.
 - **v0.4 — Scale & Polish**: Bulk operations, watch mode, plugin hooks.
 

--- a/en-quire.md
+++ b/en-quire.md
@@ -1,0 +1,179 @@
+---
+name: en-quire
+description: >
+  Instructions for using en-quire MCP tools to read, search, edit, and manage 
+  markdown documents. Use this skill whenever working with .md or .mdx files — 
+  SOPs, skill files, session memory, codex articles, specs. Covers section-addressed 
+  editing, structural search, find-replace, document creation, governance modes, 
+  and the hybrid outline+filesystem workflow for full-document review.
+compatibility:
+  tools:
+    - doc_outline
+    - doc_read_section
+    - doc_read
+    - doc_list
+    - doc_search
+    - doc_replace_section
+    - doc_append_section
+    - doc_find_replace
+    - doc_insert_section
+    - doc_delete_section
+    - doc_create
+    - doc_rename
+    - doc_generate_toc
+---
+# Skill: en-quire — Markdown Document Management
+
+**Purpose:** Instructions for agents using en-quire MCP tools to read, search, edit, and manage markdown documents.
+
+---
+
+## When to Use en-quire
+
+Use en-quire tools (`doc_*`) instead of filesystem tools (`read_file`, `write_file`, `edit_file`) for any operation on markdown files (.md, .mdx). en-quire provides section-level addressing, structural search, and diff responses that eliminate the need to read or rewrite whole files.
+
+Use filesystem tools only when:
+- You need the full file including pre-heading content (frontmatter, imports, JSX preamble)
+- You are working with non-markdown files
+- You need to move or copy files between directories
+
+---
+
+## Core Workflow: Outline → Read → Edit
+
+Every interaction with a document follows this sequence:
+
+1. **`doc_outline`** — Get the heading structure first. This is non-negotiable. Never read a whole file to orient yourself.
+2. **`doc_read_section`** — Read only the section you need. Use the heading text or path from the outline.
+3. **Edit with the right tool:**
+   - `doc_replace_section` — when you need to rewrite a section's content
+   - `doc_append_section` — when you need to add content to the end of a section (table rows, list items, paragraphs)
+   - `doc_find_replace` — when you need to change a term or phrase across the whole document
+   - `doc_insert_section` — when you need to add a new section before or after an existing one
+   - `doc_delete_section` — when you need to remove a section entirely
+
+Every write tool returns a diff. You do not need to re-read the file to verify your edit landed correctly.
+
+---
+
+## Hybrid Pattern: Outline + Filesystem Read
+
+For tasks that require seeing the whole document (proofreading, tone review, cross-section consistency checks):
+
+1. **`doc_outline`** first — get the structural map
+2. **Filesystem `read_text_file`** — read the full file with the structure already in context
+
+This is 2 calls instead of 10+ (reading every section individually). The outline primes the read — you scan the file against a known structure rather than discovering the structure while reading.
+
+Use en-quire for all subsequent edits after the full-file review.
+
+---
+
+## Search
+
+Use `doc_search` to find content across documents. Results include:
+- `section_path` — the full heading breadcrumb (e.g. "RBAC Model > Permission Types")
+- `breadcrumb[]` — ancestor headings for triaging relevance
+- `score` — structural ranking that boosts heading matches
+
+Search is section-level, not line-level. Use the section path to navigate directly to the relevant content via `doc_read_section`.
+
+Use `section_filter` to narrow results to specific parts of the document structure: "find metrics, but only within escalation procedures."
+
+---
+
+## Document Listing
+
+Use `doc_list` to see all documents in scope. This returns file paths, sizes, and modification dates. Use it before searching when you need to know what's available.
+
+---
+
+## Find and Replace
+
+`doc_find_replace` is the tool for bulk changes across a document (terminology renames, consistent corrections).
+
+**Always preview first:**
+1. Call with `preview: true` to see all matches with context, section paths, and `in_code_block` flags
+2. Review the matches — check for false positives
+3. Call again without `preview` to apply, using `expected_count` to verify you're changing the right number of instances
+
+For selective application, use `apply_matches` with specific match IDs from the preview.
+
+---
+
+## Document Creation
+
+Use `doc_create` for new documents. For session memory files, structure them with heading hierarchy so future agents can `doc_search` and `doc_append_section` into specific sections.
+
+Recommended memory file structure:
+- Design Decisions (with subsections by topic)
+- Bugs Found / Issues
+- Test Results
+- Key Learnings (the primary append target)
+- Open Questions
+- Pending Actions
+
+The heading hierarchy is the filing system. Classify the insight, map it to a section name, append.
+
+---
+
+## Governance: Write vs Propose
+
+- **`mode: "write"`** — edits go directly to the file. Use for your own documents, session memory, and when git is not initialised.
+- **`mode: "propose"`** — edits land on a git branch for review. Use for shared documents, skill files, specs, and other agents' system prompts. Requires git.
+
+If propose mode returns `proposal_requires_git`, git is not initialised in the document root. Use write mode and inform the user.
+
+---
+
+## Self-Modification Pattern
+
+When you identify an improvement to your own system prompt or skill files:
+1. `doc_read` your own prompt file to review current content
+2. Draft the specific change
+3. Apply via `doc_append_section` or `doc_replace_section` (use propose mode when available, write mode when git is not initialised)
+4. Inform the user what you changed and why
+
+---
+
+## Tone Editing Workflow
+
+When editing for voice or style consistency:
+1. **`doc_search`** across the corpus for a tonally strong reference passage — this is your voice calibration
+2. **`doc_read_section`** on the reference passage to load it as context
+3. **Filesystem `read_text_file`** on the target document for full-file voice calibration
+4. **Edit section by section** via en-quire, holding the reference voice in context
+
+Tool selection during tone edits:
+- Single-sentence fixes → `doc_find_replace`
+- Whole-section rewrites → `doc_replace_section`
+
+The full-file read prevents tone drift between section edits.
+
+---
+
+## Common Mistakes to Avoid
+
+- **Never read a whole file to orient yourself.** Use `doc_outline` first. Always.
+- **Never use filesystem `edit_file` for markdown when en-quire is available.** en-quire's section addressing eliminates line-counting errors.
+- **Never re-read after writing.** The diff in the response tells you what changed.
+- **Never skip the preview step on find-replace.** One false positive can corrupt a document.
+- **Never modify another agent's system prompt in write mode** when propose mode is available.
+
+---
+
+## Tool Quick Reference
+
+| Task | Tool | Key params |
+|------|------|------------|
+| See document structure | `doc_outline` | `file`, `max_depth?` |
+| Read a section | `doc_read_section` | `file`, `section` |
+| Read full document | `doc_read` | `file`, `page?`, `page_size?` |
+| List all documents | `doc_list` | `scope?` |
+| Search across documents | `doc_search` | `query`, `section_filter?` |
+| Replace section content | `doc_replace_section` | `file`, `section`, `content` |
+| Append to a section | `doc_append_section` | `file`, `section`, `content` |
+| Find and replace | `doc_find_replace` | `file`, `find`, `replace`, `preview?` |
+| Create new document | `doc_create` | `file`, `content` |
+| Insert new section | `doc_insert_section` | `file`, `anchor`, `position`, `heading`, `content` |
+| Delete a section | `doc_delete_section` | `file`, `section` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1866,6 +1866,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2167,6 +2168,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4159,6 +4161,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4435,6 +4438,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4551,6 +4555,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4738,6 +4743,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -4763,7 +4769,7 @@
     },
     "packages/en-core": {
       "name": "@nullproof-studio/en-core",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -4793,7 +4799,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@nullproof-studio/en-core": "0.1.5",
+        "@nullproof-studio/en-core": "0.2.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.0",
         "remark-parse": "^11.0.0",
@@ -4815,11 +4821,11 @@
     },
     "packages/en-scribe": {
       "name": "@nullproof-studio/en-scribe",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@nullproof-studio/en-core": "0.1.5",
+        "@nullproof-studio/en-core": "0.2.0",
         "zod": "^3.24.4"
       },
       "bin": {

--- a/packages/en-core/package.json
+++ b/packages/en-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nullproof-studio/en-core",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Reliability primitives shared by the en-quire and en-scribe MCP servers: etag, proposals, diff, file-utils, git, RBAC, parser registry.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/en-core/src/config/loader.ts
+++ b/packages/en-core/src/config/loader.ts
@@ -108,6 +108,7 @@ export function loadConfig(configPath: string): ResolvedConfig {
         auto_commit: root.git.auto_commit,
         remote: root.git.remote,
         pr_hook: root.git.pr_hook,
+        default_branch: root.git.default_branch,
       },
     };
   }

--- a/packages/en-core/src/config/loader.ts
+++ b/packages/en-core/src/config/loader.ts
@@ -109,6 +109,7 @@ export function loadConfig(configPath: string): ResolvedConfig {
         remote: root.git.remote,
         pr_hook: root.git.pr_hook,
         default_branch: root.git.default_branch,
+        push_proposals: root.git.push_proposals,
       },
     };
   }

--- a/packages/en-core/src/config/roots.ts
+++ b/packages/en-core/src/config/roots.ts
@@ -1,6 +1,11 @@
 // Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
 import type { ResolvedRoot } from '../shared/types.js';
 import { NotFoundError, ValidationError } from '../shared/errors.js';
+import { rankByLevenshtein } from '../shared/levenshtein.js';
+
+const ROOT_CANDIDATE_LIMIT = 20;
+const ROOT_FORMAT_HINT =
+  'With multiple roots, prefix the path with a root name (e.g. "rootname/path/to/file.md").';
 
 export interface ResolvedFile {
   rootName: string;
@@ -53,10 +58,9 @@ export function resolveFilePath(
     };
   }
 
-  throw new NotFoundError(
-    'root',
-    `Cannot resolve root for "${filePath}". With multiple roots, prefix the path with a root name: ${rootNames.join(', ')}`,
-  );
+  const wouldBeRoot = filePath.split('/')[0] || filePath;
+  const candidates = rankByLevenshtein(wouldBeRoot, rootNames, ROOT_CANDIDATE_LIMIT);
+  throw new NotFoundError('root', filePath, candidates, ROOT_FORMAT_HINT);
 }
 
 /**

--- a/packages/en-core/src/config/schema.ts
+++ b/packages/en-core/src/config/schema.ts
@@ -43,6 +43,7 @@ const RootGitSchema = z.object({
   auto_commit: z.boolean().default(true),
   remote: z.string().nullable().default(null),
   pr_hook: z.string().nullable().default(null),
+  default_branch: z.string().nullable().default(null), // null = detect from origin HEAD / local branches
 });
 
 const DocumentRootSchema = z.object({

--- a/packages/en-core/src/config/schema.ts
+++ b/packages/en-core/src/config/schema.ts
@@ -44,6 +44,7 @@ const RootGitSchema = z.object({
   remote: z.string().nullable().default(null),
   pr_hook: z.string().nullable().default(null),
   default_branch: z.string().nullable().default(null), // null = detect from origin HEAD / local branches
+  push_proposals: z.boolean().default(false), // push proposal branches to `remote` after commit
 });
 
 const DocumentRootSchema = z.object({

--- a/packages/en-core/src/document/parser-registry.ts
+++ b/packages/en-core/src/document/parser-registry.ts
@@ -51,6 +51,15 @@ class ParserRegistry {
   supportedExtensions(): string[] {
     return [...this.extensionMap.keys()];
   }
+
+  /** Return extensions whose parser declares the given capability. */
+  extensionsSupporting(capability: keyof ParserCapabilities): string[] {
+    const result: string[] = [];
+    for (const [ext, parser] of this.extensionMap) {
+      if (parser.capabilities[capability]) result.push(ext);
+    }
+    return result;
+  }
 }
 
 export const parserRegistry = new ParserRegistry();

--- a/packages/en-core/src/document/section-address.ts
+++ b/packages/en-core/src/document/section-address.ts
@@ -2,6 +2,7 @@
 import micromatch from 'micromatch';
 import type { SectionNode, SectionAddress } from '../shared/types.js';
 import { AddressResolutionError } from '../shared/errors.js';
+import { rankByLevenshtein } from '../shared/levenshtein.js';
 import { flattenTree } from './section-tree.js';
 
 /**
@@ -164,11 +165,9 @@ function addressToString(address: SectionAddress): string {
 }
 
 /**
- * Find closest matching heading texts for error messages.
+ * Find closest matching heading texts for error messages, ranked by
+ * Levenshtein distance (closest first). Tie-broken lexically.
  */
 function findClosestMatches(query: string, headings: string[], limit = 3): string[] {
-  const lower = query.toLowerCase();
-  return headings
-    .filter((h) => h.toLowerCase().includes(lower) || lower.includes(h.toLowerCase()))
-    .slice(0, limit);
+  return rankByLevenshtein(query, headings, limit);
 }

--- a/packages/en-core/src/document/section-address.ts
+++ b/packages/en-core/src/document/section-address.ts
@@ -49,11 +49,28 @@ export function resolveSingleSection(
   if (matches.length > 1) {
     throw new AddressResolutionError(
       addressToString(address),
-      `Ambiguous: ${matches.length} sections match. Use a more specific address (e.g., path or index)`,
-      matches.map((m) => m.heading.text),
+      `Ambiguous: ${matches.length} sections match. Retry with one of the disambiguated paths or indices below`,
+      matches.map(describeMatchForDisambiguation),
     );
   }
   return matches[0];
+}
+
+/**
+ * Build a disambiguating description of a matched section: its full path
+ * from root joined by " > ", plus the index path that uniquely identifies
+ * it (always works, even when sibling paths are textually identical).
+ */
+function describeMatchForDisambiguation(node: SectionNode): string {
+  const pathSegments: string[] = [];
+  const indexPath: number[] = [];
+  let curr: SectionNode | null = node;
+  while (curr) {
+    pathSegments.unshift(curr.heading.text);
+    indexPath.unshift(curr.index);
+    curr = curr.parent;
+  }
+  return `"${pathSegments.join(' > ')}" (index ${JSON.stringify(indexPath)})`;
 }
 
 function resolveTextAddress(tree: SectionNode[], text: string): SectionNode[] {

--- a/packages/en-core/src/document/section-ops-core.ts
+++ b/packages/en-core/src/document/section-ops-core.ts
@@ -553,9 +553,14 @@ export function findReplace(
 
   // Safety check
   if (expected_count !== undefined && apply_matches === undefined && matches.length !== expected_count) {
-    throw new Error(
-      `Expected ${expected_count} matches but found ${matches.length}. Use preview mode to inspect matches.`,
-    );
+    const err = new ValidationError(
+      `Expected ${expected_count} matches but found ${matches.length}. ` +
+      `Retry with preview: true to inspect matches and their applyIds, then either correct expected_count ` +
+      `or pass apply_matches: [<applyId>, ...] to target a subset.`,
+    ) as ValidationError & { expected_count: number; actual_count: number };
+    err.expected_count = expected_count;
+    err.actual_count = matches.length;
+    throw err;
   }
 
   // Apply replacements

--- a/packages/en-core/src/git/commit-message.ts
+++ b/packages/en-core/src/git/commit-message.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
 import { getProductName } from '../shared/logger.js';
+import { ValidationError } from '../shared/errors.js';
 
 export interface CommitMessageParams {
   operation: string;
@@ -35,19 +36,41 @@ export function buildCommitMessage(params: CommitMessageParams): string {
 
 /**
  * Build a branch name for a proposal.
- * Format: propose/{caller}/{document-path-with-extension}/{timestamp}
+ * Format: propose/{caller}/{document-path}/{timestamp}
  *
- * The file extension is preserved in the branch name so that extension-
- * agnostic consumers (en-quire for md/yaml, en-scribe for plain text)
- * can reconstruct the exact file path without having to guess which
- * suffix the proposal operates on.
+ * Path separators are kept as literal `/` — git allows arbitrary slashes
+ * in branch names, and a lossless encoding means the branch → path
+ * round-trip works for any file name, including paths that already
+ * contain hyphens (e.g. `skills/triage-agent.md`). The timestamp segment
+ * is a fixed-length ISO-compact form (YYYYMMDDTHHMMSSZ) that serves as
+ * the parse anchor — everything between the caller and the timestamp
+ * is the file path.
  */
 export function buildProposalBranch(caller: string, filePath: string): string {
   const timestamp = new Date().toISOString()
     .replace(/[-:]/g, '')
     .replace(/\.\d+Z$/, 'Z');
 
-  const sanitisedPath = filePath.replace(/\//g, '-');
+  return `propose/${caller}/${filePath}/${timestamp}`;
+}
 
-  return `propose/${caller}/${sanitisedPath}/${timestamp}`;
+const PROPOSAL_BRANCH_RE = /^propose\/([^/]+)\/(.+)\/(\d{8}T\d{6}Z)$/;
+
+/**
+ * Parse a proposal branch name back into its parts.
+ * The timestamp's fixed format anchors the parse: caller is the first
+ * segment, timestamp is the last, and the file path is whatever sits
+ * between. Passing a branch name not produced by `buildProposalBranch`
+ * throws `ValidationError`.
+ */
+export function parseProposalBranch(
+  branch: string,
+  root: string,
+): { caller: string; file: string; timestamp: string } {
+  const match = branch.match(PROPOSAL_BRANCH_RE);
+  if (!match) {
+    throw new ValidationError(`Malformed proposal branch name: ${branch}`);
+  }
+  const [, caller, filePath, timestamp] = match;
+  return { caller, file: `${root}/${filePath}`, timestamp };
 }

--- a/packages/en-core/src/git/commit-message.ts
+++ b/packages/en-core/src/git/commit-message.ts
@@ -54,6 +54,41 @@ export function buildProposalBranch(caller: string, filePath: string): string {
   return `propose/${caller}/${filePath}/${timestamp}`;
 }
 
+export interface ParsedCommitMetadata {
+  operation: string;
+  target: string;
+  caller: string;
+  mode: 'write' | 'propose';
+  userMessage?: string;
+}
+
+/**
+ * Parse the structured metadata block that `buildCommitMessage` emits.
+ * Returns null if any required field is missing — proposal branches are
+ * expected to carry this block on their tip commit, so a null return is a
+ * signal that either the commit predates the metadata convention or the
+ * commit wasn't produced by en-quire/en-scribe. User messages that span
+ * multiple lines will have only their first line captured — the metadata
+ * grammar is line-oriented by design.
+ */
+export function parseCommitMessage(raw: string): ParsedCommitMetadata | null {
+  const caller = /^Caller:\s*(.+?)\s*$/m.exec(raw)?.[1];
+  const operation = /^Operation:\s*(.+?)\s*$/m.exec(raw)?.[1];
+  const target = /^Target:\s*(.+?)\s*$/m.exec(raw)?.[1];
+  const mode = /^Mode:\s*(write|propose)\s*$/m.exec(raw)?.[1];
+  if (!caller || !operation || !target || !mode) return null;
+
+  const userMessage = /^Message:\s*(.+?)\s*$/m.exec(raw)?.[1];
+
+  return {
+    operation,
+    target,
+    caller,
+    mode: mode as 'write' | 'propose',
+    ...(userMessage && { userMessage }),
+  };
+}
+
 const PROPOSAL_BRANCH_RE = /^propose\/([^/]+)\/(.+)\/(\d{8}T\d{6}Z)$/;
 
 /**

--- a/packages/en-core/src/git/commit-message.ts
+++ b/packages/en-core/src/git/commit-message.ts
@@ -70,15 +70,39 @@ export interface ParsedCommitMetadata {
  * commit wasn't produced by en-quire/en-scribe. User messages that span
  * multiple lines will have only their first line captured — the metadata
  * grammar is line-oriented by design.
+ *
+ * Implemented as a line-by-line scan rather than per-field regex to avoid
+ * polynomial backtracking on pathological whitespace input (flagged by
+ * CodeQL on an earlier regex-based version).
  */
 export function parseCommitMessage(raw: string): ParsedCommitMetadata | null {
-  const caller = /^Caller:\s*(.+?)\s*$/m.exec(raw)?.[1];
-  const operation = /^Operation:\s*(.+?)\s*$/m.exec(raw)?.[1];
-  const target = /^Target:\s*(.+?)\s*$/m.exec(raw)?.[1];
-  const mode = /^Mode:\s*(write|propose)\s*$/m.exec(raw)?.[1];
-  if (!caller || !operation || !target || !mode) return null;
+  let caller: string | undefined;
+  let operation: string | undefined;
+  let target: string | undefined;
+  let mode: string | undefined;
+  let userMessage: string | undefined;
 
-  const userMessage = /^Message:\s*(.+?)\s*$/m.exec(raw)?.[1];
+  for (const line of raw.split('\n')) {
+    // Simple `Field: value` recogniser. trim() on the value is linear,
+    // startsWith() on the prefix is linear, no backtracking.
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const name = line.slice(0, colon);
+    const value = line.slice(colon + 1).trim();
+    if (value === '') continue;
+
+    switch (name) {
+      case 'Caller': caller ??= value; break;
+      case 'Operation': operation ??= value; break;
+      case 'Target': target ??= value; break;
+      case 'Mode':
+        if (value === 'write' || value === 'propose') mode ??= value;
+        break;
+      case 'Message': userMessage ??= value; break;
+    }
+  }
+
+  if (!caller || !operation || !target || !mode) return null;
 
   return {
     operation,

--- a/packages/en-core/src/git/operations.ts
+++ b/packages/en-core/src/git/operations.ts
@@ -183,6 +183,43 @@ export class GitOperations {
     return await this.git.diff([`${def}...${branch}`]);
   }
 
+  /**
+   * Fetch the tip commit of a proposal branch along with the shortstat
+   * diff against the default branch. The caller combines these with
+   * `parseCommitMessage` to populate the structured metadata fields on
+   * `doc_proposals_list` / `doc_proposal_diff` responses.
+   */
+  async getProposalTipCommit(branch: string): Promise<{
+    sha: string;
+    authorDate: string;
+    message: string;
+    diffSummary: string;
+  }> {
+    this.requireGit('get proposal tip');
+
+    // Use a unique delimiter to isolate the full commit message (subject + body)
+    // from git-log's default field-separated output. `%H` = SHA, `%aI` = author
+    // date ISO 8601-strict, `%B` = raw body including subject.
+    const DELIM = '\x1Fen-quire-log-end\x1F';
+    const raw = await this.git.raw(['log', '-1', `--format=%H%n%aI%n%B${DELIM}`, branch]);
+    const endIdx = raw.indexOf(DELIM);
+    if (endIdx < 0) {
+      throw new Error(`No commits on branch: ${branch}`);
+    }
+    const [sha, authorDate, ...bodyLines] = raw.slice(0, endIdx).split('\n');
+    const message = bodyLines.join('\n').trimEnd();
+
+    const def = await this.resolveDefaultBranch();
+    const shortstat = (await this.git.raw(['diff', '--shortstat', `${def}...${branch}`])).trim();
+
+    return {
+      sha,
+      authorDate,
+      message,
+      diffSummary: shortstat,
+    };
+  }
+
   async getModifiedFiles(): Promise<string[]> {
     this.requireGit('get modified files');
     const status = await this.git.status();

--- a/packages/en-core/src/git/operations.ts
+++ b/packages/en-core/src/git/operations.ts
@@ -1,7 +1,12 @@
 // Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
 import { simpleGit, type SimpleGit } from 'simple-git';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { GitRequiredError } from '../shared/errors.js';
+import { tokeniseCommand } from '../shared/tokenise-command.js';
 import { detectGit } from './detector.js';
+
+const execFileAsync = promisify(execFile);
 
 export class GitOperations {
   private git: SimpleGit;
@@ -10,6 +15,8 @@ export class GitOperations {
   private _defaultBranch?: string;
   private _remote: string | null;
   private _pushProposals: boolean;
+  private _prHook: string | null;
+  private _documentRoot: string;
 
   constructor(
     documentRoot: string,
@@ -17,13 +24,16 @@ export class GitOperations {
     configuredDefaultBranch?: string | null,
     remote?: string | null,
     pushProposals?: boolean | null,
+    prHook?: string | null,
   ) {
+    this._documentRoot = documentRoot;
     this.git = simpleGit(documentRoot);
     const detection = detectGit(documentRoot);
     this._available = forceEnabled === false ? false : detection.available;
     this._configuredDefault = configuredDefaultBranch ?? null;
     this._remote = remote ?? null;
     this._pushProposals = pushProposals === true;
+    this._prHook = prHook ?? null;
   }
 
   get available(): boolean {
@@ -131,6 +141,48 @@ export class GitOperations {
   async deleteBranch(branch: string): Promise<void> {
     this.requireGit('delete branch');
     await this.git.deleteLocalBranch(branch, true);
+  }
+
+  /**
+   * Run the configured `git.pr_hook` command with per-token substitution
+   * of `{branch}`, `{file}`, and `{caller}`. The command is tokenised FIRST,
+   * then each token is substituted individually, so a substituted value that
+   * contains whitespace or shell metacharacters cannot split into new argv
+   * entries. Uses `execFile` (never `exec`), so the shell is never invoked.
+   *
+   * Returns `{ ran: false }` quietly when the hook is not configured. Hook
+   * failures (non-zero exit, missing command, timeout) surface as warnings,
+   * never thrown — a failed hook must not roll back the proposal commit
+   * that already landed.
+   */
+  async runPrHook(subs: { branch: string; file: string; caller: string }): Promise<{ ran: boolean; warning?: string }> {
+    if (!this._prHook) return { ran: false };
+
+    const tokens = tokeniseCommand(this._prHook);
+    if (tokens.length === 0) {
+      return { ran: false, warning: 'pr_hook is set but empty after tokenisation' };
+    }
+
+    const substitute = (t: string): string => t
+      .replaceAll('{branch}', subs.branch)
+      .replaceAll('{file}', subs.file)
+      .replaceAll('{caller}', subs.caller);
+
+    const [program, ...rest] = tokens.map(substitute);
+
+    try {
+      await execFileAsync(program, rest, {
+        cwd: this._documentRoot,
+        timeout: 30_000,
+        maxBuffer: 1_048_576,
+      });
+      return { ran: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const code = (err as NodeJS.ErrnoException | { code?: number }).code;
+      const codeSuffix = code !== undefined ? ` (exit ${code})` : '';
+      return { ran: false, warning: `pr_hook failed${codeSuffix}: ${msg}` };
+    }
   }
 
   /**

--- a/packages/en-core/src/git/operations.ts
+++ b/packages/en-core/src/git/operations.ts
@@ -2,7 +2,7 @@
 import { simpleGit, type SimpleGit } from 'simple-git';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { GitRequiredError } from '../shared/errors.js';
+import { GitRequiredError, ValidationError } from '../shared/errors.js';
 import { tokeniseCommand } from '../shared/tokenise-command.js';
 import { detectGit } from './detector.js';
 
@@ -186,6 +186,27 @@ export class GitOperations {
   }
 
   /**
+   * Run `git fetch --prune` against the configured remote. Returns
+   * `{ ok: false }` quietly when no remote is configured, and returns a
+   * warning string (rather than throwing) on network failures so callers
+   * can decide whether to continue gracefully or abort. Used both at
+   * bin startup and as the first step of the safe-approve pre-flight.
+   */
+  async fetchAndPrune(): Promise<{ ok: boolean; warning?: string }> {
+    this.requireGit('fetch');
+    if (!this._remote) {
+      return { ok: false };
+    }
+    try {
+      await this.git.raw(['fetch', '--prune', this._remote]);
+      return { ok: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, warning: `fetch --prune ${this._remote} failed: ${msg}` };
+    }
+  }
+
+  /**
    * Push a proposal branch to the configured remote when the root's
    * `git.push_proposals` flag is on. Returns `{ pushed: false }` quietly
    * when either the remote or the flag is not set — the caller doesn't
@@ -208,6 +229,14 @@ export class GitOperations {
 
   /**
    * Merge a proposal branch into the default branch with safety guarantees:
+   *   0. PRE-FLIGHT — if the root has a remote configured, fetch --prune
+   *      and verify the proposal branch still exists on the remote.
+   *      Refuses if the branch is gone (merged / rejected upstream) or
+   *      the remote can't be reached; both cases mean we cannot verify
+   *      the proposal's upstream state and merging blindly could produce
+   *      a local merge commit that diverges from origin's merge commit,
+   *      breaking the next `git push`. Skipped when no remote is
+   *      configured (local-only proposals).
    *   1. Remember the caller's current branch.
    *   2. Ensure the working tree is on the default branch before the merge
    *      — otherwise the merge would land on whatever happened to be
@@ -222,6 +251,30 @@ export class GitOperations {
    */
   async approveProposal(branch: string, message: string): Promise<{ merge_commit: string }> {
     this.requireGit('approve proposal');
+
+    // Pre-flight: verify remote state before any mutation. Same principle
+    // as etag checks on document writes — writes verify, reads don't.
+    if (this._remote) {
+      const fetchResult = await this.fetchAndPrune();
+      if (!fetchResult.ok) {
+        throw new ValidationError(
+          `Cannot verify remote state of "${branch}" — ${fetchResult.warning ?? 'remote unreachable'}. ` +
+          `Approval refused to prevent divergent history. Try again when the remote is reachable.`,
+        );
+      }
+      try {
+        // show-ref --verify exits 128 (rejects) with stderr "fatal:..." when
+        // the ref is missing, which simple-git surfaces as a thrown error.
+        // The --quiet form exits 1 silently and simple-git treats that as
+        // success — so we use the noisy form and swallow the stderr here.
+        await this.git.raw(['show-ref', '--verify', `refs/remotes/${this._remote}/${branch}`]);
+      } catch {
+        throw new ValidationError(
+          `Proposal branch "${branch}" is no longer on remote "${this._remote}" — ` +
+          `likely merged or rejected upstream already. Pull the default branch to reconcile local state.`,
+        );
+      }
+    }
 
     const original = await this.getCurrentBranch();
     const def = await this.resolveDefaultBranch();

--- a/packages/en-core/src/git/operations.ts
+++ b/packages/en-core/src/git/operations.ts
@@ -127,6 +127,46 @@ export class GitOperations {
     await this.git.deleteLocalBranch(branch, true);
   }
 
+  /**
+   * Merge a proposal branch into the default branch with safety guarantees:
+   *   1. Remember the caller's current branch.
+   *   2. Ensure the working tree is on the default branch before the merge
+   *      — otherwise the merge would land on whatever happened to be
+   *      checked out.
+   *   3. Merge (--no-ff), capture the merge commit SHA, delete the branch.
+   *   4. In `finally`, attempt to restore the caller's original branch —
+   *      unless the original was the proposal itself (just deleted) or
+   *      was already the default.
+   * If the merge throws (e.g. a conflict once detection lands), the finally
+   * still runs so the working tree doesn't drift away from where the caller
+   * left it.
+   */
+  async approveProposal(branch: string, message: string): Promise<{ merge_commit: string }> {
+    this.requireGit('approve proposal');
+
+    const original = await this.getCurrentBranch();
+    const def = await this.resolveDefaultBranch();
+    const shouldRestore = original !== branch && original !== def;
+
+    try {
+      if (original !== def) {
+        await this.git.checkout(def);
+      }
+      await this.mergeBranch(branch, message);
+      const mergeCommit = (await this.git.raw(['rev-parse', 'HEAD'])).trim();
+      await this.deleteBranch(branch);
+      return { merge_commit: mergeCommit };
+    } finally {
+      if (shouldRestore) {
+        try {
+          await this.git.checkout(original);
+        } catch {
+          // Original branch no longer reachable — leave the tree on default.
+        }
+      }
+    }
+  }
+
   async listBranches(pattern?: string): Promise<string[]> {
     this.requireGit('list branches');
     const result = await this.git.branchLocal();

--- a/packages/en-core/src/git/operations.ts
+++ b/packages/en-core/src/git/operations.ts
@@ -8,16 +8,22 @@ export class GitOperations {
   private _available: boolean;
   private _configuredDefault: string | null;
   private _defaultBranch?: string;
+  private _remote: string | null;
+  private _pushProposals: boolean;
 
   constructor(
     documentRoot: string,
     forceEnabled?: boolean | null,
     configuredDefaultBranch?: string | null,
+    remote?: string | null,
+    pushProposals?: boolean | null,
   ) {
     this.git = simpleGit(documentRoot);
     const detection = detectGit(documentRoot);
     this._available = forceEnabled === false ? false : detection.available;
     this._configuredDefault = configuredDefaultBranch ?? null;
+    this._remote = remote ?? null;
+    this._pushProposals = pushProposals === true;
   }
 
   get available(): boolean {
@@ -125,6 +131,27 @@ export class GitOperations {
   async deleteBranch(branch: string): Promise<void> {
     this.requireGit('delete branch');
     await this.git.deleteLocalBranch(branch, true);
+  }
+
+  /**
+   * Push a proposal branch to the configured remote when the root's
+   * `git.push_proposals` flag is on. Returns `{ pushed: false }` quietly
+   * when either the remote or the flag is not set — the caller doesn't
+   * need to pre-check. Push errors are caught and surfaced as a warning
+   * string so the local commit is not clobbered when the network fails.
+   */
+  async pushProposalBranch(branch: string): Promise<{ pushed: boolean; warning?: string }> {
+    this.requireGit('push proposal branch');
+    if (!this._remote || !this._pushProposals) {
+      return { pushed: false };
+    }
+    try {
+      await this.git.push(this._remote, branch);
+      return { pushed: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { pushed: false, warning: `Failed to push ${branch} to ${this._remote}: ${msg}` };
+    }
   }
 
   /**

--- a/packages/en-core/src/git/operations.ts
+++ b/packages/en-core/src/git/operations.ts
@@ -6,11 +6,18 @@ import { detectGit } from './detector.js';
 export class GitOperations {
   private git: SimpleGit;
   private _available: boolean;
+  private _configuredDefault: string | null;
+  private _defaultBranch?: string;
 
-  constructor(documentRoot: string, forceEnabled?: boolean | null) {
+  constructor(
+    documentRoot: string,
+    forceEnabled?: boolean | null,
+    configuredDefaultBranch?: string | null,
+  ) {
     this.git = simpleGit(documentRoot);
     const detection = detectGit(documentRoot);
     this._available = forceEnabled === false ? false : detection.available;
+    this._configuredDefault = configuredDefaultBranch ?? null;
   }
 
   get available(): boolean {
@@ -21,6 +28,55 @@ export class GitOperations {
     if (!this._available) {
       throw new GitRequiredError(operation);
     }
+  }
+
+  /**
+   * Resolve the repo's default branch name. Precedence:
+   *   1. `git.default_branch` from config (explicit override)
+   *   2. `refs/remotes/origin/HEAD` (what origin says is default)
+   *   3. Local `main` or `master`, in that order
+   *   4. Fallback to `main`
+   * The result is memoised — a repo's default branch doesn't change during
+   * a server session, so one probe is enough.
+   */
+  async resolveDefaultBranch(): Promise<string> {
+    this.requireGit('resolve default branch');
+    if (this._defaultBranch) return this._defaultBranch;
+
+    if (this._configuredDefault) {
+      this._defaultBranch = this._configuredDefault;
+      return this._defaultBranch;
+    }
+
+    const remoteHead = await this.detectRemoteHead();
+    if (remoteHead) {
+      this._defaultBranch = remoteHead;
+      return this._defaultBranch;
+    }
+
+    this._defaultBranch = await this.detectLocalDefault();
+    return this._defaultBranch;
+  }
+
+  private async detectRemoteHead(): Promise<string | null> {
+    try {
+      const result = await this.git.raw(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD']);
+      const trimmed = result.trim();
+      return trimmed.startsWith('origin/') ? trimmed.slice('origin/'.length) : trimmed;
+    } catch {
+      return null;
+    }
+  }
+
+  private async detectLocalDefault(): Promise<string> {
+    try {
+      const { all } = await this.git.branchLocal();
+      if (all.includes('main')) return 'main';
+      if (all.includes('master')) return 'master';
+    } catch {
+      // fall through
+    }
+    return 'main';
   }
 
   async commitFile(filePath: string, message: string): Promise<string> {
@@ -47,14 +103,10 @@ export class GitOperations {
     await this.git.checkout(name);
   }
 
-  async switchToMain(): Promise<void> {
-    this.requireGit('switch to main');
-    // Try 'main' first, fall back to 'master'
-    try {
-      await this.git.checkout('main');
-    } catch {
-      await this.git.checkout('master');
-    }
+  async switchToDefault(): Promise<void> {
+    this.requireGit('switch to default branch');
+    const def = await this.resolveDefaultBranch();
+    await this.git.checkout(def);
   }
 
   async getCurrentBranch(): Promise<string> {
@@ -87,7 +139,8 @@ export class GitOperations {
 
   async getDiff(branch: string): Promise<string> {
     this.requireGit('get diff');
-    return await this.git.diff(['main...', branch]);
+    const def = await this.resolveDefaultBranch();
+    return await this.git.diff([`${def}...${branch}`]);
   }
 
   async getModifiedFiles(): Promise<string[]> {
@@ -98,7 +151,8 @@ export class GitOperations {
 
   async getLog(branch?: string): Promise<Array<{ hash: string; message: string; date: string }>> {
     this.requireGit('get log');
-    const options = branch ? { from: 'main', to: branch } : {};
+    const def = branch ? await this.resolveDefaultBranch() : undefined;
+    const options = branch ? { from: def, to: branch } : {};
     const log = await this.git.log(options);
     return log.all.map((entry) => ({
       hash: entry.hash,

--- a/packages/en-core/src/git/post-propose.ts
+++ b/packages/en-core/src/git/post-propose.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import type { Logger } from 'winston';
+import type { GitOperations } from './operations.js';
+
+/**
+ * Run the post-propose side effects — push the branch to the configured
+ * remote (if any), then fire the pr_hook (if any) when the push landed.
+ *
+ * Every path that commits a proposal branch needs this sequence; the
+ * shared helper keeps the 6 lifecycle/write tools from drifting out of
+ * sync on logging, ordering, and warning handling.
+ *
+ * Returns an array of warning strings to fold into the tool response.
+ * Failures never throw out — the proposal commit has already landed and
+ * must not be rolled back by a network or hook hiccup.
+ */
+export async function runPostProposeHooks(
+  git: GitOperations,
+  params: { branch: string; file: string; caller: string },
+  logger: Logger,
+): Promise<string[]> {
+  const warnings: string[] = [];
+
+  const pushResult = await git.pushProposalBranch(params.branch);
+
+  if (pushResult.pushed) {
+    logger.info('propose:pushed', params);
+
+    const hookResult = await git.runPrHook(params);
+    if (hookResult.ran) {
+      logger.info('propose:pr-hook-ran', params);
+    }
+    if (hookResult.warning) {
+      logger.warn('propose:pr-hook-failed', { ...params, warning: hookResult.warning });
+      warnings.push(hookResult.warning);
+    }
+  }
+
+  if (pushResult.warning) {
+    logger.warn('propose:push-failed', { ...params, warning: pushResult.warning });
+    warnings.push(pushResult.warning);
+  }
+
+  return warnings;
+}

--- a/packages/en-core/src/index.ts
+++ b/packages/en-core/src/index.ts
@@ -6,6 +6,7 @@ export * from './shared/encoding.js';
 export * from './shared/errors.js';
 export * from './shared/etag.js';
 export * from './shared/file-utils.js';
+export * from './shared/levenshtein.js';
 export * from './shared/logger.js';
 export * from './shared/tokenise-command.js';
 export * from './shared/types.js';

--- a/packages/en-core/src/index.ts
+++ b/packages/en-core/src/index.ts
@@ -7,6 +7,7 @@ export * from './shared/errors.js';
 export * from './shared/etag.js';
 export * from './shared/file-utils.js';
 export * from './shared/logger.js';
+export * from './shared/tokenise-command.js';
 export * from './shared/types.js';
 export * from './shared/word-count.js';
 
@@ -26,6 +27,7 @@ export * from './rbac/types.js';
 export * from './git/commit-message.js';
 export * from './git/detector.js';
 export * from './git/operations.js';
+export * from './git/post-propose.js';
 
 // Search
 export * from './search/database.js';

--- a/packages/en-core/src/shared/errors.ts
+++ b/packages/en-core/src/shared/errors.ts
@@ -15,11 +15,13 @@ export class NotFoundError extends EnquireError {
     public readonly resource: 'file' | 'section' | 'root',
     public readonly target: string,
     public readonly candidates?: string[],
+    formatHint?: string,
   ) {
+    const fmt = formatHint ? ` ${formatHint}` : '';
     const hint = candidates?.length
       ? ` Did you mean: ${candidates.join(', ')}?`
       : '';
-    super('not_found', `${resource} not found: "${target}".${hint}`);
+    super('not_found', `${resource} not found: "${target}".${fmt}${hint}`);
     this.name = 'NotFoundError';
   }
 }

--- a/packages/en-core/src/shared/levenshtein.ts
+++ b/packages/en-core/src/shared/levenshtein.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+
+/**
+ * Compute the Levenshtein edit distance between two strings.
+ * Two-row dynamic programming — O(m*n) time, O(min(m,n)) space.
+ */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  const m = a.length;
+  const n = b.length;
+  let prev = new Array<number>(n + 1);
+  let curr = new Array<number>(n + 1);
+  for (let j = 0; j <= n; j++) prev[j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min(
+        prev[j] + 1,
+        curr[j - 1] + 1,
+        prev[j - 1] + cost,
+      );
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n];
+}
+
+/**
+ * Rank candidates by Levenshtein distance to `query` and return the closest
+ * `limit` matches. Comparison is case-insensitive; ties break lexically on the
+ * original (case-preserving) candidate string for deterministic output.
+ */
+export function rankByLevenshtein(
+  query: string,
+  candidates: string[],
+  limit: number,
+): string[] {
+  if (candidates.length === 0 || limit <= 0) return [];
+  const lq = query.toLowerCase();
+  return candidates
+    .map((c) => ({ c, d: levenshtein(lq, c.toLowerCase()) }))
+    .sort((a, b) => a.d - b.d || a.c.localeCompare(b.c))
+    .slice(0, limit)
+    .map((x) => x.c);
+}

--- a/packages/en-core/src/shared/tokenise-command.ts
+++ b/packages/en-core/src/shared/tokenise-command.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+
+/**
+ * Tokenise a shell-style command string into [program, ...args].
+ * Handles single quotes, double quotes, and escaped characters.
+ * Does NOT process shell expansions, redirections, or pipes — callers
+ * are expected to pass the result to `execFile`, which bypasses shell
+ * interpretation entirely.
+ */
+export function tokeniseCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  let escaped = false;
+  let hasQuoted = false;
+
+  for (const ch of command) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+
+    if (ch === '\\' && !inSingle) {
+      escaped = true;
+      continue;
+    }
+
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      hasQuoted = true;
+      continue;
+    }
+
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      hasQuoted = true;
+      continue;
+    }
+
+    if (/\s/.test(ch) && !inSingle && !inDouble) {
+      if (current.length > 0 || hasQuoted) {
+        tokens.push(current);
+        current = '';
+        hasQuoted = false;
+      }
+      continue;
+    }
+
+    current += ch;
+  }
+
+  if (current.length > 0 || hasQuoted) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}

--- a/packages/en-core/src/shared/types.ts
+++ b/packages/en-core/src/shared/types.ts
@@ -152,6 +152,7 @@ export interface RootGitConfig {
   remote: string | null;
   pr_hook: string | null;
   default_branch: string | null; // null = detect from origin HEAD / local branches
+  push_proposals: boolean; // push proposal branches to `remote` after commit
 }
 
 /** A resolved document root */

--- a/packages/en-core/src/shared/types.ts
+++ b/packages/en-core/src/shared/types.ts
@@ -151,6 +151,7 @@ export interface RootGitConfig {
   auto_commit: boolean;
   remote: string | null;
   pr_hook: string | null;
+  default_branch: string | null; // null = detect from origin HEAD / local branches
 }
 
 /** A resolved document root */

--- a/packages/en-core/src/tools/proposals.ts
+++ b/packages/en-core/src/tools/proposals.ts
@@ -136,12 +136,11 @@ export async function handleProposalApprove(
   requirePermission(ctx.caller, 'approve', file);
 
   const mergeMessage = args.message ?? `[${getProductName()}] Approve proposal: ${args.branch}`;
-  await git.mergeBranch(args.branch, mergeMessage);
-  await git.deleteBranch(args.branch);
+  const { merge_commit } = await git.approveProposal(args.branch, mergeMessage);
 
   return {
     success: true,
-    merge_commit: '',
+    merge_commit,
     file,
     branch: args.branch,
   };

--- a/packages/en-core/src/tools/proposals.ts
+++ b/packages/en-core/src/tools/proposals.ts
@@ -4,8 +4,9 @@ import type { ToolContext } from './context.js';
 import { requirePermission } from '../rbac/permissions.js';
 import { GitRequiredError, ValidationError } from '../shared/errors.js';
 import { getProductName } from '../shared/logger.js';
-import { parseProposalBranch } from '../git/commit-message.js';
+import { parseProposalBranch, parseCommitMessage } from '../git/commit-message.js';
 import type { GitOperations } from '../git/operations.js';
+import { getLogger } from '../shared/logger.js';
 
 /**
  * Format-agnostic proposal governance handlers.
@@ -47,22 +48,48 @@ async function collectProposals(ctx: ToolContext) {
     diff_summary: string;
   }> = [];
 
+  const log = getLogger();
+
   for (const [name, rootCtx] of Object.entries(ctx.roots)) {
     if (!rootCtx.git?.available) continue;
 
     const branches = await rootCtx.git.listBranches('propose/');
     for (const branch of branches) {
       const { caller, file, timestamp } = parseProposalBranch(branch, name);
+
+      let section = '';
+      let operation = '';
+      let message = '';
+      let created = timestamp;
+      let diff_summary = '';
+
+      try {
+        const tip = await rootCtx.git.getProposalTipCommit(branch);
+        created = tip.authorDate;
+        diff_summary = tip.diffSummary;
+
+        const meta = parseCommitMessage(tip.message);
+        if (meta) {
+          section = meta.target;
+          operation = meta.operation;
+          message = meta.userMessage ?? '';
+        }
+      } catch (err) {
+        // Branch exists but tip inspection failed (e.g. shallow clone,
+        // missing ref). Fall back to branch-name-derived fields.
+        log.warn('proposals:tip-inspection-failed', { branch, error: String(err) });
+      }
+
       allProposals.push({
         branch,
         caller,
         file,
         root: name,
-        section: '',
-        operation: '',
-        message: '',
-        created: timestamp,
-        diff_summary: '',
+        section,
+        operation,
+        message,
+        created,
+        diff_summary,
       });
     }
   }
@@ -111,7 +138,15 @@ export async function handleProposalDiff(
 
   const diff = await git.getDiff(args.branch);
 
-  return { diff, file, caller, message: '' };
+  let message = '';
+  try {
+    const tip = await git.getProposalTipCommit(args.branch);
+    message = parseCommitMessage(tip.message)?.userMessage ?? '';
+  } catch {
+    // Leave message empty if tip inspection fails.
+  }
+
+  return { diff, file, caller, message };
 }
 
 // --- proposal_approve ---

--- a/packages/en-core/src/tools/proposals.ts
+++ b/packages/en-core/src/tools/proposals.ts
@@ -4,16 +4,16 @@ import type { ToolContext } from './context.js';
 import { requirePermission } from '../rbac/permissions.js';
 import { GitRequiredError, ValidationError } from '../shared/errors.js';
 import { getProductName } from '../shared/logger.js';
+import { parseProposalBranch } from '../git/commit-message.js';
 import type { GitOperations } from '../git/operations.js';
 
 /**
  * Format-agnostic proposal governance handlers.
  *
  * Shared by en-quire (registered as doc_proposals_*) and en-scribe
- * (registered as text_proposals_*). Branch reconstruction no longer
- * assumes a markdown extension — buildProposalBranch preserves the
- * original file extension, so parsing a branch back gives the exact
- * path regardless of the binary that created it.
+ * (registered as text_proposals_*). Branch names encode paths with
+ * literal `/` separators so the branch → file round-trip is lossless
+ * regardless of the binary that created the proposal.
  */
 
 function findGitRoot(ctx: ToolContext, rootName?: string): { name: string; git: GitOperations } {
@@ -32,16 +32,6 @@ function findGitRoot(ctx: ToolContext, rootName?: string): { name: string; git: 
   }
 
   throw new GitRequiredError('Proposals (no git-enabled roots)');
-}
-
-/** Reconstruct a file path from a propose/ branch name. Format: propose/{caller}/{path-with-dashes}/{timestamp}. */
-function parseProposalBranch(branch: string, root: string): { caller: string; file: string; timestamp: string } {
-  const parts = branch.replace('propose/', '').split('/');
-  const caller = parts[0];
-  const timestamp = parts[parts.length - 1];
-  const fileParts = parts.slice(1, -1);
-  const file = `${root}/${fileParts.join('/')}`;
-  return { caller, file, timestamp };
 }
 
 async function collectProposals(ctx: ToolContext) {

--- a/packages/en-core/src/tools/runtime.ts
+++ b/packages/en-core/src/tools/runtime.ts
@@ -28,11 +28,16 @@ export function wrapHandler<T>(
     } catch (err) {
       const durationMs = Math.round(performance.now() - start);
       const error = err instanceof EnquireError
-        ? {
-            error: err.code,
-            message: err.message,
-            ...('current_etag' in err && { current_etag: (err as { current_etag?: string }).current_etag }),
-          }
+        ? (() => {
+            const errExtras = err as unknown as { current_etag?: string; candidates?: unknown };
+            return {
+              error: err.code,
+              message: err.message,
+              ...(typeof errExtras.current_etag === 'string' && { current_etag: errExtras.current_etag }),
+              ...(Array.isArray(errExtras.candidates) && errExtras.candidates.length > 0
+                && { candidates: errExtras.candidates as string[] }),
+            };
+          })()
         : { error: 'internal_error', message: String(err) };
       logger.error('tool:error', { tool, error: error.error, message: error.message, durationMs });
       return {

--- a/packages/en-core/src/tools/runtime.ts
+++ b/packages/en-core/src/tools/runtime.ts
@@ -29,13 +29,20 @@ export function wrapHandler<T>(
       const durationMs = Math.round(performance.now() - start);
       const error = err instanceof EnquireError
         ? (() => {
-            const errExtras = err as unknown as { current_etag?: string; candidates?: unknown };
+            const errExtras = err as unknown as {
+              current_etag?: string;
+              candidates?: unknown;
+              actual_count?: unknown;
+              expected_count?: unknown;
+            };
             return {
               error: err.code,
               message: err.message,
               ...(typeof errExtras.current_etag === 'string' && { current_etag: errExtras.current_etag }),
               ...(Array.isArray(errExtras.candidates) && errExtras.candidates.length > 0
                 && { candidates: errExtras.candidates as string[] }),
+              ...(typeof errExtras.actual_count === 'number' && { actual_count: errExtras.actual_count }),
+              ...(typeof errExtras.expected_count === 'number' && { expected_count: errExtras.expected_count }),
             };
           })()
         : { error: 'internal_error', message: String(err) };

--- a/packages/en-core/src/tools/write-helpers.ts
+++ b/packages/en-core/src/tools/write-helpers.ts
@@ -6,6 +6,7 @@ import { parserRegistry } from '../document/parser-registry.js';
 import type { DocumentParser } from '../document/parser-registry.js';
 import { indexDocument } from '../search/indexer.js';
 import { buildCommitMessage, buildProposalBranch } from '../git/commit-message.js';
+import { runPostProposeHooks } from '../git/post-propose.js';
 import { generateDiff } from '../shared/diff.js';
 import { resolveWriteMode } from '../rbac/permissions.js';
 import { GitRequiredError, ValidationError } from '../shared/errors.js';
@@ -109,17 +110,12 @@ export async function executeWrite(
       commit = await git.commitFile(resolved.relativePath, commitMsg);
       logger.debug('write:git-committed', { file: params.file, commit });
 
-      // Push proposal branches to the configured remote (no-op unless
-      // git.remote + git.push_proposals are both set on the root).
       if (mode === 'propose' && branch) {
-        const pushResult = await git.pushProposalBranch(branch);
-        if (pushResult.pushed) {
-          logger.info('write:pushed', { file: params.file, branch });
-        }
-        if (pushResult.warning) {
-          logger.warn('write:push-failed', { file: params.file, branch, warning: pushResult.warning });
-          warnings.push(pushResult.warning);
-        }
+        warnings.push(...await runPostProposeHooks(
+          git,
+          { branch, file: params.file, caller: ctx.caller.id },
+          logger,
+        ));
       }
     }
 

--- a/packages/en-core/src/tools/write-helpers.ts
+++ b/packages/en-core/src/tools/write-helpers.ts
@@ -108,6 +108,19 @@ export async function executeWrite(
       });
       commit = await git.commitFile(resolved.relativePath, commitMsg);
       logger.debug('write:git-committed', { file: params.file, commit });
+
+      // Push proposal branches to the configured remote (no-op unless
+      // git.remote + git.push_proposals are both set on the root).
+      if (mode === 'propose' && branch) {
+        const pushResult = await git.pushProposalBranch(branch);
+        if (pushResult.pushed) {
+          logger.info('write:pushed', { file: params.file, branch });
+        }
+        if (pushResult.warning) {
+          logger.warn('write:push-failed', { file: params.file, branch, warning: pushResult.warning });
+          warnings.push(pushResult.warning);
+        }
+      }
     }
 
     // Update search index (use prefixed path for index key)

--- a/packages/en-core/test/unit/config/roots.test.ts
+++ b/packages/en-core/test/unit/config/roots.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
 import { describe, it, expect } from 'vitest';
-import { resolveFilePath, resolveScope } from '@nullproof-studio/en-core';
+import { resolveFilePath, resolveScope, NotFoundError } from '@nullproof-studio/en-core';
 import type { ResolvedRoot } from '@nullproof-studio/en-core';
 
 const singleRoot: Record<string, ResolvedRoot> = {
@@ -60,12 +60,45 @@ describe('resolveFilePath', () => {
 
   it('throws on bare path in multi-root config', () => {
     expect(() => resolveFilePath(multiRoots, 'article.md'))
-      .toThrow('Cannot resolve root');
+      .toThrow(NotFoundError);
   });
 
-  it('throws on unknown root prefix', () => {
-    expect(() => resolveFilePath(multiRoots, 'unknown/file.md'))
-      .toThrow('Cannot resolve root');
+  it('throws on unknown root prefix with ranked candidates and format hint', () => {
+    let caught: unknown;
+    try {
+      resolveFilePath(multiRoots, 'docz/file.md');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(NotFoundError);
+    const err = caught as NotFoundError;
+    expect(err.resource).toBe('root');
+    expect(err.candidates).toBeDefined();
+    // "docs" is closest to "docz" (distance 1) and should rank first
+    expect(err.candidates![0]).toBe('docs');
+    expect(err.candidates!.length).toBeLessThanOrEqual(20);
+    expect(err.message).toContain('docs');
+    // Format hint should explain how to prefix paths
+    expect(err.message).toMatch(/prefix the path with a root name/i);
+  });
+
+  it('caps candidate list at 20', () => {
+    const manyRoots: Record<string, ResolvedRoot> = {};
+    for (let i = 0; i < 50; i++) {
+      manyRoots[`root${i}`] = {
+        name: `root${i}`,
+        path: `/data/root${i}`,
+        git: { enabled: null, auto_commit: true, remote: null, pr_hook: null },
+      };
+    }
+    let caught: unknown;
+    try {
+      resolveFilePath(manyRoots, 'unknown/file.md');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(NotFoundError);
+    expect((caught as NotFoundError).candidates!.length).toBe(20);
   });
 
   it('throws on root-only path (no file)', () => {

--- a/packages/en-core/test/unit/git/approve-proposal.test.ts
+++ b/packages/en-core/test/unit/git/approve-proposal.test.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { simpleGit, type SimpleGit } from 'simple-git';
+import { GitOperations } from '@nullproof-studio/en-core';
+
+let repoDir: string;
+let g: SimpleGit;
+
+beforeEach(async () => {
+  repoDir = mkdtempSync(join(tmpdir(), 'approve-proposal-'));
+  g = simpleGit(repoDir);
+  await g.init();
+  await g.addConfig('user.email', 'test@example.com');
+  await g.addConfig('user.name', 'Test');
+  await g.addConfig('commit.gpgsign', 'false');
+  await g.raw(['symbolic-ref', 'HEAD', 'refs/heads/main']);
+  writeFileSync(join(repoDir, 'README'), 'base\n');
+  await g.add('README');
+  await g.commit('init');
+});
+
+afterEach(() => {
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+async function makeProposal(branchName: string, file: string, content: string): Promise<void> {
+  await g.checkoutLocalBranch(branchName);
+  writeFileSync(join(repoDir, file), content);
+  await g.add(file);
+  await g.commit(`proposal: add ${file}`);
+  await g.checkout('main');
+}
+
+describe('GitOperations.approveProposal', () => {
+  it('merges onto the default branch and returns the merge commit SHA', async () => {
+    await makeProposal('propose/m/a.md/20260424T170000Z', 'a.md', 'payload\n');
+    const ops = new GitOperations(repoDir);
+
+    const { merge_commit } = await ops.approveProposal(
+      'propose/m/a.md/20260424T170000Z',
+      'Approve a.md',
+    );
+
+    expect(merge_commit).toMatch(/^[0-9a-f]{40}$/);
+    // Main now has a merge commit as HEAD
+    const head = (await g.raw(['rev-parse', 'HEAD'])).trim();
+    expect(head).toBe(merge_commit);
+    // The merge commit is on main
+    const current = (await g.raw(['symbolic-ref', '--short', 'HEAD'])).trim();
+    expect(current).toBe('main');
+  });
+
+  it('deletes the proposal branch on success', async () => {
+    const branchName = 'propose/m/a.md/20260424T170000Z';
+    await makeProposal(branchName, 'a.md', 'payload\n');
+    const ops = new GitOperations(repoDir);
+
+    await ops.approveProposal(branchName, 'Approve');
+
+    const { all } = await g.branchLocal();
+    expect(all).not.toContain(branchName);
+  });
+
+  it('switches to default before merging, even when called from an unrelated branch', async () => {
+    await makeProposal('propose/m/a.md/20260424T170000Z', 'a.md', 'payload\n');
+    // Put the working tree on a third branch so the merge has to switch
+    await g.checkoutLocalBranch('unrelated');
+    writeFileSync(join(repoDir, 'other'), 'x\n');
+    await g.add('other');
+    await g.commit('unrelated work');
+
+    const ops = new GitOperations(repoDir);
+    await ops.approveProposal('propose/m/a.md/20260424T170000Z', 'Approve');
+
+    // After approve, we should be back on 'unrelated' — the caller's original branch
+    const current = (await g.raw(['symbolic-ref', '--short', 'HEAD'])).trim();
+    expect(current).toBe('unrelated');
+
+    // And main has the merge commit with the proposal's payload
+    await g.checkout('main');
+    const mainLog = await g.log({ from: 'HEAD~1', to: 'HEAD' });
+    expect(mainLog.all[0].message).toContain('Approve');
+  });
+
+  it('stays on default when the caller was on the proposal branch (now deleted)', async () => {
+    const branchName = 'propose/m/a.md/20260424T170000Z';
+    await makeProposal(branchName, 'a.md', 'payload\n');
+    await g.checkout(branchName);
+
+    const ops = new GitOperations(repoDir);
+    await ops.approveProposal(branchName, 'Approve');
+
+    const current = (await g.raw(['symbolic-ref', '--short', 'HEAD'])).trim();
+    expect(current).toBe('main');
+  });
+
+  it('stays on default when the caller was already on default', async () => {
+    await makeProposal('propose/m/a.md/20260424T170000Z', 'a.md', 'payload\n');
+    // already on main from beforeEach
+
+    const ops = new GitOperations(repoDir);
+    await ops.approveProposal('propose/m/a.md/20260424T170000Z', 'Approve');
+
+    const current = (await g.raw(['symbolic-ref', '--short', 'HEAD'])).trim();
+    expect(current).toBe('main');
+  });
+
+  it('honours a non-main default branch', async () => {
+    // Rebuild the repo on master instead
+    rmSync(repoDir, { recursive: true, force: true });
+    repoDir = mkdtempSync(join(tmpdir(), 'approve-proposal-master-'));
+    g = simpleGit(repoDir);
+    await g.init();
+    await g.addConfig('user.email', 'test@example.com');
+    await g.addConfig('user.name', 'Test');
+    await g.addConfig('commit.gpgsign', 'false');
+    await g.raw(['symbolic-ref', 'HEAD', 'refs/heads/master']);
+    writeFileSync(join(repoDir, 'README'), 'base\n');
+    await g.add('README');
+    await g.commit('init');
+
+    await g.checkoutLocalBranch('propose/m/a.md/20260424T170000Z');
+    writeFileSync(join(repoDir, 'a.md'), 'payload\n');
+    await g.add('a.md');
+    await g.commit('proposal');
+    await g.checkout('master');
+
+    const ops = new GitOperations(repoDir);
+    const { merge_commit } = await ops.approveProposal(
+      'propose/m/a.md/20260424T170000Z',
+      'Approve',
+    );
+
+    const current = (await g.raw(['symbolic-ref', '--short', 'HEAD'])).trim();
+    expect(current).toBe('master');
+    expect(merge_commit).toMatch(/^[0-9a-f]{40}$/);
+  });
+});

--- a/packages/en-core/test/unit/git/commit-message.test.ts
+++ b/packages/en-core/test/unit/git/commit-message.test.ts
@@ -1,6 +1,11 @@
 // Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
 import { describe, it, expect } from 'vitest';
-import { buildCommitMessage, buildProposalBranch, parseProposalBranch } from '@nullproof-studio/en-core';
+import {
+  buildCommitMessage,
+  buildProposalBranch,
+  parseProposalBranch,
+  parseCommitMessage,
+} from '@nullproof-studio/en-core';
 import { ValidationError } from '@nullproof-studio/en-core';
 
 describe('buildCommitMessage', () => {
@@ -48,6 +53,63 @@ describe('buildProposalBranch', () => {
   it('handles nested paths', () => {
     const branch = buildProposalBranch('alice', 'docs/sops/deploy.md');
     expect(branch).toMatch(/^propose\/alice\/docs\/sops\/deploy\.md\/\d{8}T\d{6}Z$/);
+  });
+});
+
+describe('parseCommitMessage', () => {
+  it('round-trips a message built by buildCommitMessage', () => {
+    const raw = buildCommitMessage({
+      operation: 'Replace section',
+      target: '2.7 Checks',
+      file: 'sops/deployment.md',
+      caller: 'michelle',
+      mode: 'write',
+    });
+    const parsed = parseCommitMessage(raw);
+    expect(parsed).toEqual({
+      operation: 'Replace section',
+      target: '2.7 Checks',
+      caller: 'michelle',
+      mode: 'write',
+    });
+  });
+
+  it('includes the optional user message when present', () => {
+    const raw = buildCommitMessage({
+      operation: 'Append',
+      target: 'Overview',
+      file: 'docs/readme.md',
+      caller: 'bot',
+      mode: 'propose',
+      userMessage: 'Added new requirement',
+    });
+    const parsed = parseCommitMessage(raw);
+    expect(parsed?.userMessage).toBe('Added new requirement');
+    expect(parsed?.mode).toBe('propose');
+  });
+
+  it('returns null for input with no structured metadata block', () => {
+    expect(parseCommitMessage('Some plain commit message')).toBeNull();
+  });
+
+  it('returns null when required fields are missing', () => {
+    // Only Caller and Operation — no Target / Mode
+    expect(parseCommitMessage('Caller: x\nOperation: y')).toBeNull();
+  });
+
+  it('tolerates trailing whitespace and extra blank lines', () => {
+    const raw = [
+      '[en-quire] Append "Overview" in docs/a.md',
+      '',
+      'Caller: alice ',
+      'Operation: Append',
+      'Target: Overview',
+      'Mode: write',
+      '',
+    ].join('\n');
+    const parsed = parseCommitMessage(raw);
+    expect(parsed?.caller).toBe('alice');
+    expect(parsed?.operation).toBe('Append');
   });
 });
 

--- a/packages/en-core/test/unit/git/commit-message.test.ts
+++ b/packages/en-core/test/unit/git/commit-message.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
 import { describe, it, expect } from 'vitest';
-import { buildCommitMessage, buildProposalBranch } from '@nullproof-studio/en-core';
+import { buildCommitMessage, buildProposalBranch, parseProposalBranch } from '@nullproof-studio/en-core';
+import { ValidationError } from '@nullproof-studio/en-core';
 
 describe('buildCommitMessage', () => {
   it('builds a structured commit message', () => {
@@ -34,13 +35,59 @@ describe('buildCommitMessage', () => {
 });
 
 describe('buildProposalBranch', () => {
-  it('preserves the file extension so branch → file reconstruction is lossless', () => {
+  it('encodes paths with literal / separators (git allows them in branch names)', () => {
     const branch = buildProposalBranch('michelle', 'skills/triage-agent.md');
-    expect(branch).toMatch(/^propose\/michelle\/skills-triage-agent\.md\/\d{8}T\d{4}\d{2}Z$/);
+    expect(branch).toMatch(/^propose\/michelle\/skills\/triage-agent\.md\/\d{8}T\d{6}Z$/);
   });
 
   it('works for plain-text extensions too', () => {
     const branch = buildProposalBranch('bot', 'notes/todo.txt');
-    expect(branch).toMatch(/^propose\/bot\/notes-todo\.txt\/\d{8}T\d{4}\d{2}Z$/);
+    expect(branch).toMatch(/^propose\/bot\/notes\/todo\.txt\/\d{8}T\d{6}Z$/);
+  });
+
+  it('handles nested paths', () => {
+    const branch = buildProposalBranch('alice', 'docs/sops/deploy.md');
+    expect(branch).toMatch(/^propose\/alice\/docs\/sops\/deploy\.md\/\d{8}T\d{6}Z$/);
+  });
+});
+
+describe('parseProposalBranch', () => {
+  it('round-trips a simple path', () => {
+    const branch = buildProposalBranch('michelle', 'skills/triage.md');
+    const parsed = parseProposalBranch(branch, 'notes');
+    expect(parsed.caller).toBe('michelle');
+    expect(parsed.file).toBe('notes/skills/triage.md');
+  });
+
+  it('round-trips a path that contains hyphens (the case the old - encoding corrupted)', () => {
+    const branch = buildProposalBranch('michelle', 'skills/triage-agent.md');
+    const parsed = parseProposalBranch(branch, 'notes');
+    expect(parsed.caller).toBe('michelle');
+    expect(parsed.file).toBe('notes/skills/triage-agent.md');
+  });
+
+  it('round-trips nested paths', () => {
+    const branch = buildProposalBranch('alice', 'docs/sops/rollback-plan.md');
+    const parsed = parseProposalBranch(branch, 'root');
+    expect(parsed.file).toBe('root/docs/sops/rollback-plan.md');
+  });
+
+  it('round-trips plain-text paths with hyphens', () => {
+    const branch = buildProposalBranch('bot', 'notes/to-do-list.txt');
+    const parsed = parseProposalBranch(branch, 'scratch');
+    expect(parsed.file).toBe('scratch/notes/to-do-list.txt');
+  });
+
+  it('extracts a well-formed ISO-compact timestamp', () => {
+    const branch = buildProposalBranch('m', 'a.md');
+    const parsed = parseProposalBranch(branch, 'r');
+    expect(parsed.timestamp).toMatch(/^\d{8}T\d{6}Z$/);
+  });
+
+  it('rejects malformed branch names', () => {
+    expect(() => parseProposalBranch('not-a-proposal-branch', 'root'))
+      .toThrow(ValidationError);
+    expect(() => parseProposalBranch('propose/caller/no-timestamp', 'root'))
+      .toThrow(ValidationError);
   });
 });

--- a/packages/en-core/test/unit/git/default-branch.test.ts
+++ b/packages/en-core/test/unit/git/default-branch.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { simpleGit } from 'simple-git';
+import { GitOperations } from '@nullproof-studio/en-core';
+
+let repoDir: string;
+
+beforeEach(() => {
+  repoDir = mkdtempSync(join(tmpdir(), 'git-default-branch-'));
+});
+
+afterEach(() => {
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+async function initRepoOnBranch(dir: string, branch: string): Promise<void> {
+  const g = simpleGit(dir);
+  await g.init();
+  await g.addConfig('user.email', 'test@example.com');
+  await g.addConfig('user.name', 'Test');
+  await g.addConfig('commit.gpgsign', 'false');
+  await g.raw(['symbolic-ref', 'HEAD', `refs/heads/${branch}`]);
+  writeFileSync(join(dir, 'README'), 'x\n');
+  await g.add('README');
+  await g.commit('init');
+}
+
+describe('GitOperations.resolveDefaultBranch', () => {
+  it('uses the configured override when provided', async () => {
+    await initRepoOnBranch(repoDir, 'main');
+    const ops = new GitOperations(repoDir, null, 'trunk');
+    expect(await ops.resolveDefaultBranch()).toBe('trunk');
+  });
+
+  it('detects main for a main-based repo', async () => {
+    await initRepoOnBranch(repoDir, 'main');
+    const ops = new GitOperations(repoDir);
+    expect(await ops.resolveDefaultBranch()).toBe('main');
+  });
+
+  it('detects master for a master-based repo', async () => {
+    await initRepoOnBranch(repoDir, 'master');
+    const ops = new GitOperations(repoDir);
+    expect(await ops.resolveDefaultBranch()).toBe('master');
+  });
+
+  it('memoises the resolved value', async () => {
+    await initRepoOnBranch(repoDir, 'main');
+    const ops = new GitOperations(repoDir);
+    const first = await ops.resolveDefaultBranch();
+    const second = await ops.resolveDefaultBranch();
+    expect(first).toBe(second);
+    expect(first).toBe('main');
+  });
+
+  it('throws when git is not available', async () => {
+    // No init — repoDir has no .git
+    const ops = new GitOperations(repoDir);
+    await expect(ops.resolveDefaultBranch()).rejects.toThrow();
+  });
+});
+
+describe('GitOperations.getDiff uses the resolved default branch', () => {
+  it('diffs against master in a master-based repo (no hardcoded main)', async () => {
+    await initRepoOnBranch(repoDir, 'master');
+    const g = simpleGit(repoDir);
+    // Create a feature branch with a new commit
+    await g.checkoutLocalBranch('feature/x');
+    writeFileSync(join(repoDir, 'NEW'), 'payload\n');
+    await g.add('NEW');
+    await g.commit('add NEW');
+
+    const ops = new GitOperations(repoDir);
+    const diff = await ops.getDiff('feature/x');
+    expect(diff).toContain('NEW');
+    expect(diff).toContain('payload');
+  });
+});

--- a/packages/en-core/test/unit/git/pr-hook.test.ts
+++ b/packages/en-core/test/unit/git/pr-hook.test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { simpleGit, type SimpleGit } from 'simple-git';
+import { GitOperations } from '@nullproof-studio/en-core';
+
+let repoDir: string;
+
+beforeEach(async () => {
+  repoDir = mkdtempSync(join(tmpdir(), 'pr-hook-'));
+  const g: SimpleGit = simpleGit(repoDir);
+  await g.init();
+  await g.addConfig('user.email', 'test@example.com');
+  await g.addConfig('user.name', 'Test');
+  await g.addConfig('commit.gpgsign', 'false');
+  await g.raw(['symbolic-ref', 'HEAD', 'refs/heads/main']);
+  writeFileSync(join(repoDir, 'README'), 'base\n');
+  await g.add('README');
+  await g.commit('init');
+});
+
+afterEach(() => {
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+describe('GitOperations.runPrHook', () => {
+  it('is a no-op when pr_hook is not configured', async () => {
+    const ops = new GitOperations(repoDir, null, null, null, false, null);
+    const result = await ops.runPrHook({ branch: 'b', file: 'f', caller: 'c' });
+    expect(result.ran).toBe(false);
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('runs the hook command and returns ran:true on success', async () => {
+    // Write a shell script that echoes its substituted args to a marker file
+    const marker = join(repoDir, 'hook-output');
+    const hook = join(repoDir, 'hook.sh');
+    writeFileSync(hook, `#!/bin/sh\necho "branch=$1 file=$2 caller=$3" > "${marker}"\n`, { mode: 0o755 });
+
+    const ops = new GitOperations(
+      repoDir, null, null, null, false,
+      `${hook} {branch} {file} {caller}`,
+    );
+    const result = await ops.runPrHook({
+      branch: 'propose/m/a.md/20260424T170000Z',
+      file: 'a.md',
+      caller: 'michelle',
+    });
+
+    expect(result.ran).toBe(true);
+    expect(result.warning).toBeUndefined();
+
+    const { readFileSync } = await import('node:fs');
+    const out = readFileSync(marker, 'utf8').trim();
+    expect(out).toBe('branch=propose/m/a.md/20260424T170000Z file=a.md caller=michelle');
+  });
+
+  it('returns a warning when the hook exits non-zero', async () => {
+    const ops = new GitOperations(repoDir, null, null, null, false, 'false');
+    const result = await ops.runPrHook({ branch: 'b', file: 'f', caller: 'c' });
+    expect(result.ran).toBe(false);
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toMatch(/exit/i);
+  });
+
+  it('returns a warning when the hook command does not exist', async () => {
+    const ops = new GitOperations(repoDir, null, null, null, false, 'this-command-does-not-exist-kljh');
+    const result = await ops.runPrHook({ branch: 'b', file: 'f', caller: 'c' });
+    expect(result.ran).toBe(false);
+    expect(result.warning).toBeDefined();
+  });
+
+  it('treats substituted tokens as argv values — does not re-tokenise on special chars', async () => {
+    // If file is "a; rm -rf /", a shell-interpreted command would be disastrous.
+    // execFile bypasses the shell, and substitution happens per-token, so this
+    // is just a single argv entry.
+    const marker = join(repoDir, 'hook-output');
+    const hook = join(repoDir, 'hook.sh');
+    writeFileSync(hook, `#!/bin/sh\nprintf '%s' "$1" > "${marker}"\n`, { mode: 0o755 });
+
+    const ops = new GitOperations(repoDir, null, null, null, false, `${hook} {file}`);
+    const result = await ops.runPrHook({
+      branch: 'b',
+      file: 'a; rm -rf /',
+      caller: 'c',
+    });
+
+    expect(result.ran).toBe(true);
+    const { readFileSync } = await import('node:fs');
+    expect(readFileSync(marker, 'utf8')).toBe('a; rm -rf /');
+  });
+});

--- a/packages/en-core/test/unit/git/proposal-metadata.test.ts
+++ b/packages/en-core/test/unit/git/proposal-metadata.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { simpleGit, type SimpleGit } from 'simple-git';
+import { GitOperations, buildCommitMessage } from '@nullproof-studio/en-core';
+
+let repoDir: string;
+let g: SimpleGit;
+
+beforeEach(async () => {
+  repoDir = mkdtempSync(join(tmpdir(), 'proposal-meta-'));
+  g = simpleGit(repoDir);
+  await g.init();
+  await g.addConfig('user.email', 'test@example.com');
+  await g.addConfig('user.name', 'Test');
+  await g.addConfig('commit.gpgsign', 'false');
+  await g.raw(['symbolic-ref', 'HEAD', 'refs/heads/main']);
+  writeFileSync(join(repoDir, 'README'), 'base\n');
+  await g.add('README');
+  await g.commit('init');
+});
+
+afterEach(() => {
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+describe('GitOperations.getProposalTipCommit', () => {
+  it('returns SHA, author date, full message and diff summary for a proposal tip', async () => {
+    const commitBody = buildCommitMessage({
+      operation: 'Replace section',
+      target: '2.7 Checks',
+      file: 'sops/deployment.md',
+      caller: 'michelle',
+      mode: 'propose',
+      userMessage: 'Update threshold',
+    });
+
+    await g.checkoutLocalBranch('propose/michelle/sops/deployment.md/20260424T170000Z');
+    writeFileSync(join(repoDir, 'payload.md'), '# section\ncontent\n');
+    await g.add('payload.md');
+    await g.commit(commitBody);
+
+    // Stay on propose — getProposalTipCommit should not care
+    const ops = new GitOperations(repoDir);
+    const tip = await ops.getProposalTipCommit('propose/michelle/sops/deployment.md/20260424T170000Z');
+
+    expect(tip.sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(tip.authorDate).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(tip.message).toContain('Caller: michelle');
+    expect(tip.message).toContain('Operation: Replace section');
+    expect(tip.message).toContain('Target: 2.7 Checks');
+    expect(tip.message).toContain('Mode: propose');
+    expect(tip.message).toContain('Message: Update threshold');
+    // Diff summary reflects the single-file add
+    expect(tip.diffSummary).toMatch(/1 file changed.*insertion/);
+  });
+
+  it('returns an empty diff summary when the branch has no changes vs default', async () => {
+    await g.checkoutLocalBranch('propose/empty/a.md/20260424T170000Z');
+    await g.commit('empty change', undefined, { '--allow-empty': null });
+
+    const ops = new GitOperations(repoDir);
+    const tip = await ops.getProposalTipCommit('propose/empty/a.md/20260424T170000Z');
+    expect(tip.diffSummary).toBe('');
+  });
+});

--- a/packages/en-core/test/unit/git/push-proposal.test.ts
+++ b/packages/en-core/test/unit/git/push-proposal.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { simpleGit, type SimpleGit } from 'simple-git';
+import { GitOperations } from '@nullproof-studio/en-core';
+
+let workDir: string;
+let remoteDir: string;
+let g: SimpleGit;
+
+beforeEach(async () => {
+  workDir = mkdtempSync(join(tmpdir(), 'push-work-'));
+  remoteDir = mkdtempSync(join(tmpdir(), 'push-remote-'));
+
+  // Bare "remote"
+  const bare = simpleGit(remoteDir);
+  await bare.init(true);
+
+  // Working repo wired to it
+  g = simpleGit(workDir);
+  await g.init();
+  await g.addConfig('user.email', 'test@example.com');
+  await g.addConfig('user.name', 'Test');
+  await g.addConfig('commit.gpgsign', 'false');
+  await g.raw(['symbolic-ref', 'HEAD', 'refs/heads/main']);
+  writeFileSync(join(workDir, 'README'), 'base\n');
+  await g.add('README');
+  await g.commit('init');
+  await g.addRemote('origin', remoteDir);
+  await g.push(['-u', 'origin', 'main']);
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+  rmSync(remoteDir, { recursive: true, force: true });
+});
+
+async function makeProposal(branch: string, file: string, content: string): Promise<void> {
+  await g.checkoutLocalBranch(branch);
+  writeFileSync(join(workDir, file), content);
+  await g.add(file);
+  await g.commit(`proposal: add ${file}`);
+  await g.checkout('main');
+}
+
+describe('GitOperations.pushProposalBranch', () => {
+  it('pushes the branch when remote and push_proposals are configured', async () => {
+    const branch = 'propose/m/a.md/20260424T170000Z';
+    await makeProposal(branch, 'a.md', 'payload\n');
+
+    const ops = new GitOperations(workDir, null, null, 'origin', true);
+    const result = await ops.pushProposalBranch(branch);
+    expect(result.pushed).toBe(true);
+    expect(result.warning).toBeUndefined();
+
+    // Branch now exists on the bare remote
+    const remote = simpleGit(remoteDir);
+    const branches = await remote.branch();
+    expect(branches.all).toContain(branch);
+  });
+
+  it('is a no-op when no remote is configured', async () => {
+    const branch = 'propose/m/a.md/20260424T170000Z';
+    await makeProposal(branch, 'a.md', 'payload\n');
+
+    const ops = new GitOperations(workDir, null, null, null, true);
+    const result = await ops.pushProposalBranch(branch);
+    expect(result.pushed).toBe(false);
+    expect(result.warning).toBeUndefined();
+
+    // Branch NOT on remote
+    const remote = simpleGit(remoteDir);
+    const branches = await remote.branch();
+    expect(branches.all).not.toContain(branch);
+  });
+
+  it('is a no-op when push_proposals is false, even with a remote', async () => {
+    const branch = 'propose/m/a.md/20260424T170000Z';
+    await makeProposal(branch, 'a.md', 'payload\n');
+
+    const ops = new GitOperations(workDir, null, null, 'origin', false);
+    const result = await ops.pushProposalBranch(branch);
+    expect(result.pushed).toBe(false);
+
+    const remote = simpleGit(remoteDir);
+    const branches = await remote.branch();
+    expect(branches.all).not.toContain(branch);
+  });
+
+  it('returns a warning instead of throwing when push fails', async () => {
+    const branch = 'propose/m/a.md/20260424T170000Z';
+    await makeProposal(branch, 'a.md', 'payload\n');
+
+    // Non-existent remote
+    const ops = new GitOperations(workDir, null, null, 'no-such-remote', true);
+    const result = await ops.pushProposalBranch(branch);
+    expect(result.pushed).toBe(false);
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toContain('no-such-remote');
+  });
+});

--- a/packages/en-core/test/unit/git/safe-approve.test.ts
+++ b/packages/en-core/test/unit/git/safe-approve.test.ts
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { simpleGit, type SimpleGit } from 'simple-git';
+import { GitOperations, ValidationError } from '@nullproof-studio/en-core';
+
+let workDir: string;
+let remoteDir: string;
+let g: SimpleGit;
+
+beforeEach(async () => {
+  workDir = mkdtempSync(join(tmpdir(), 'safe-approve-work-'));
+  remoteDir = mkdtempSync(join(tmpdir(), 'safe-approve-remote-'));
+
+  const bare = simpleGit(remoteDir);
+  await bare.init(true);
+
+  g = simpleGit(workDir);
+  await g.init();
+  await g.addConfig('user.email', 'test@example.com');
+  await g.addConfig('user.name', 'Test');
+  await g.addConfig('commit.gpgsign', 'false');
+  await g.raw(['symbolic-ref', 'HEAD', 'refs/heads/main']);
+  writeFileSync(join(workDir, 'README'), 'base\n');
+  await g.add('README');
+  await g.commit('init');
+  await g.addRemote('origin', remoteDir);
+  await g.push(['-u', 'origin', 'main']);
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+  rmSync(remoteDir, { recursive: true, force: true });
+});
+
+async function makeAndPushProposal(branch: string, file: string, content: string): Promise<void> {
+  await g.checkoutLocalBranch(branch);
+  writeFileSync(join(workDir, file), content);
+  await g.add(file);
+  await g.commit(`proposal: add ${file}`);
+  await g.push('origin', branch);
+  await g.checkout('main');
+}
+
+describe('GitOperations.fetchAndPrune', () => {
+  it('fetches and prunes when remote is configured', async () => {
+    const ops = new GitOperations(workDir, null, null, 'origin', true);
+    const result = await ops.fetchAndPrune();
+    expect(result.ok).toBe(true);
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('returns { ok: false } when no remote is configured', async () => {
+    const ops = new GitOperations(workDir, null, null, null, false);
+    const result = await ops.fetchAndPrune();
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns a warning instead of throwing on network failure', async () => {
+    const ops = new GitOperations(workDir, null, null, 'no-such-remote', true);
+    const result = await ops.fetchAndPrune();
+    expect(result.ok).toBe(false);
+    expect(result.warning).toBeDefined();
+  });
+
+  it('after prune, a remote-deleted branch disappears from origin/* refs', async () => {
+    const branch = 'propose/m/a.md/20260424T170000Z';
+    await makeAndPushProposal(branch, 'a.md', 'payload\n');
+
+    // Simulate upstream merge + branch deletion on the remote
+    const bare = simpleGit(remoteDir);
+    await bare.raw(['update-ref', '-d', `refs/heads/${branch}`]);
+
+    const ops = new GitOperations(workDir, null, null, 'origin', true);
+    const result = await ops.fetchAndPrune();
+    expect(result.ok).toBe(true);
+
+    // The remote-tracking ref should now be gone. `show-ref --verify`
+    // (without --quiet) exits 128 with a fatal message on stderr for a
+    // missing ref, which simple-git surfaces as a thrown error. The
+    // --quiet variant exits 1 silently and simple-git resolves it.
+    await expect(
+      g.raw(['show-ref', '--verify', `refs/remotes/origin/${branch}`]),
+    ).rejects.toThrow();
+  });
+});
+
+describe('GitOperations.approveProposal — safe pre-flight', () => {
+  it('refuses to approve when the remote branch has been deleted upstream', async () => {
+    const branch = 'propose/m/a.md/20260424T170000Z';
+    await makeAndPushProposal(branch, 'a.md', 'payload\n');
+
+    // Remote-side removal (as GitHub "merge + delete branch" would do)
+    const bare = simpleGit(remoteDir);
+    await bare.raw(['update-ref', '-d', `refs/heads/${branch}`]);
+
+    const ops = new GitOperations(workDir, null, null, 'origin', true);
+    await expect(ops.approveProposal(branch, 'Approve from MCP'))
+      .rejects.toThrow(ValidationError);
+    await expect(ops.approveProposal(branch, 'Approve from MCP'))
+      .rejects.toThrow(/no longer on remote|handled upstream/i);
+
+    // Local branch must still exist — approve refused, nothing destructive
+    const { all } = await g.branchLocal();
+    expect(all).toContain(branch);
+  });
+
+  it('allows approve when the remote branch is still present (happy path)', async () => {
+    const branch = 'propose/m/b.md/20260424T170000Z';
+    await makeAndPushProposal(branch, 'b.md', 'content\n');
+
+    const ops = new GitOperations(workDir, null, null, 'origin', true);
+    const { merge_commit } = await ops.approveProposal(branch, 'Approve');
+    expect(merge_commit).toMatch(/^[0-9a-f]{40}$/);
+
+    const { all } = await g.branchLocal();
+    expect(all).not.toContain(branch);
+  });
+
+  it('skips pre-flight when no remote is configured (local-only proposal)', async () => {
+    // Make a proposal that was never pushed
+    const branch = 'propose/m/local.md/20260424T170000Z';
+    await g.checkoutLocalBranch(branch);
+    writeFileSync(join(workDir, 'local.md'), 'local\n');
+    await g.add('local.md');
+    await g.commit('local proposal');
+    await g.checkout('main');
+
+    // GitOperations with no remote configured
+    const ops = new GitOperations(workDir, null, null, null, false);
+    const { merge_commit } = await ops.approveProposal(branch, 'Approve');
+    expect(merge_commit).toMatch(/^[0-9a-f]{40}$/);
+
+    const { all } = await g.branchLocal();
+    expect(all).not.toContain(branch);
+  });
+
+  it('refuses approval when the remote is unreachable (fail-closed)', async () => {
+    const branch = 'propose/m/c.md/20260424T170000Z';
+    await makeAndPushProposal(branch, 'c.md', 'payload\n');
+
+    // Point at a bogus remote so the pre-flight fetch fails
+    const ops = new GitOperations(workDir, null, null, 'no-such-remote', true);
+    await expect(ops.approveProposal(branch, 'Approve'))
+      .rejects.toThrow(ValidationError);
+
+    // Local branch must still exist — approve refused
+    const { all } = await g.branchLocal();
+    expect(all).toContain(branch);
+  });
+});

--- a/packages/en-core/test/unit/shared/levenshtein.test.ts
+++ b/packages/en-core/test/unit/shared/levenshtein.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect } from 'vitest';
+import { levenshtein, rankByLevenshtein } from '@nullproof-studio/en-core';
+
+describe('levenshtein', () => {
+  it('returns 0 for identical strings', () => {
+    expect(levenshtein('docs', 'docs')).toBe(0);
+  });
+
+  it('returns length of other string when one is empty', () => {
+    expect(levenshtein('', 'docs')).toBe(4);
+    expect(levenshtein('docs', '')).toBe(4);
+  });
+
+  it('counts a single substitution', () => {
+    expect(levenshtein('docs', 'dogs')).toBe(1);
+  });
+
+  it('counts a single insertion', () => {
+    expect(levenshtein('docs', 'doces')).toBe(1);
+  });
+
+  it('counts a single deletion', () => {
+    expect(levenshtein('docs', 'dcs')).toBe(1);
+  });
+
+  it('counts mixed edits', () => {
+    expect(levenshtein('kitten', 'sitting')).toBe(3);
+  });
+});
+
+describe('rankByLevenshtein', () => {
+  it('returns the closest matches first', () => {
+    const result = rankByLevenshtein('docs', ['memory', 'docs', 'dogs', 'docks'], 4);
+    expect(result.slice(0, 3)).toEqual(['docs', 'docks', 'dogs']);
+    expect(result[3]).toBe('memory');
+  });
+
+  it('caps results at limit', () => {
+    const candidates = ['docs', 'dogs', 'doxs', 'docx', 'dock'];
+    const result = rankByLevenshtein('docs', candidates, 3);
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe('docs');
+  });
+
+  it('breaks ties lexically for determinism', () => {
+    // All distance 1 from "docs"
+    const result = rankByLevenshtein('docs', ['zogs', 'aogs', 'mogs'], 3);
+    expect(result).toEqual(['aogs', 'mogs', 'zogs']);
+  });
+
+  it('is case-insensitive when ranking', () => {
+    const result = rankByLevenshtein('DOCS', ['skills', 'Docs', 'memory'], 1);
+    expect(result).toEqual(['Docs']);
+  });
+
+  it('returns empty array for empty candidate list', () => {
+    expect(rankByLevenshtein('docs', [], 20)).toEqual([]);
+  });
+
+  it('handles limit larger than candidate count', () => {
+    const result = rankByLevenshtein('docs', ['dogs', 'cats'], 20);
+    expect(result.length).toBe(2);
+  });
+});

--- a/packages/en-core/test/unit/tools/runtime.test.ts
+++ b/packages/en-core/test/unit/tools/runtime.test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect } from 'vitest';
+import {
+  wrapHandler,
+  NotFoundError,
+  PreconditionFailedError,
+  ValidationError,
+} from '@nullproof-studio/en-core';
+import type { ToolContext } from '@nullproof-studio/en-core';
+
+const ctx = {} as ToolContext;
+
+async function runAndParse<T>(
+  handler: (args: T, ctx: ToolContext) => Promise<unknown>,
+  args: T,
+): Promise<{ isError?: boolean; payload: Record<string, unknown> }> {
+  const wrapped = wrapHandler<T>('test_tool', ctx, handler);
+  const result = await wrapped(args);
+  const text = result.content[0].text;
+  return { isError: result.isError, payload: JSON.parse(text) };
+}
+
+describe('wrapHandler error serialization', () => {
+  it('spreads candidates from NotFoundError into the JSON payload', async () => {
+    const { isError, payload } = await runAndParse(async () => {
+      throw new NotFoundError('root', 'docz/file.md', ['docs', 'dogs', 'memory'], 'Prefix the path.');
+    }, {});
+    expect(isError).toBe(true);
+    expect(payload.error).toBe('not_found');
+    expect(payload.candidates).toEqual(['docs', 'dogs', 'memory']);
+    expect(payload.message).toContain('Prefix the path.');
+    expect(payload.message).toContain('Did you mean: docs, dogs, memory?');
+  });
+
+  it('omits candidates when the error has none', async () => {
+    const { payload } = await runAndParse(async () => {
+      throw new ValidationError('bad input');
+    }, {});
+    expect(payload.error).toBe('validation_error');
+    expect(payload).not.toHaveProperty('candidates');
+  });
+
+  it('still spreads current_etag from PreconditionFailedError', async () => {
+    const { payload } = await runAndParse(async () => {
+      throw new PreconditionFailedError('docs/foo.md', 'etag-123', 'stale');
+    }, {});
+    expect(payload.current_etag).toBe('etag-123');
+  });
+});

--- a/packages/en-quire/README.md
+++ b/packages/en-quire/README.md
@@ -26,6 +26,28 @@ All parsers implement the same `DocumentParser` interface, so every `doc_*` tool
 
 `doc_search` indexes markdown and YAML files only. JSONL is excluded deliberately: record-oriented data (chat transcripts, training samples, event logs) tends to be noisy in FTS — large content fields, repetitive role prefixes, and record counts that quickly outweigh prose documents — and its primary access pattern is record-by-index via `doc_read_section`, not substring search across the corpus. `doc_status` still surfaces JSONL files under `unindexed`, which is accurate rather than a warning. If search over JSONL content turns out to be a real need later, we can add it per-root behind a config flag.
 
+## Governance workflow
+
+Proposals can become real pull requests on GitHub/GitLab. Configure the remote, the push flag, and a `pr_hook` on a root:
+
+```yaml
+document_roots:
+  docs:
+    path: /data/docs
+    git:
+      remote: origin
+      push_proposals: true
+      pr_hook: "gh pr create --head {branch} --title 'Proposal: {file}' --base main"
+```
+
+Every `mode: "propose"` write then runs the full pipeline:
+
+1. Commits to a `propose/<caller>/<path>/<timestamp>` branch locally
+2. Pushes to the remote
+3. Fires `pr_hook` with `{branch}` / `{file}` / `{caller}` substitution (via `execFile` — no shell)
+
+Approvals happen via `doc_proposal_approve` (merges locally after verifying the remote branch still exists — fails closed if it was merged upstream already) or via the PR UI on your host. Server startup runs `git fetch --prune` per git-enabled root so `doc_proposals_list` stays current across sessions.
+
 ## Usage
 
 See the [repo README](https://github.com/nullproof-studio/en-quire#readme) for configuration, tool reference, and the full spec.

--- a/packages/en-quire/package.json
+++ b/packages/en-quire/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@nullproof-studio/en-core": "0.1.5",
+    "@nullproof-studio/en-core": "0.2.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",
     "remark-parse": "^11.0.0",

--- a/packages/en-quire/src/bin.ts
+++ b/packages/en-quire/src/bin.ts
@@ -84,6 +84,7 @@ async function main() {
       root.git.default_branch,
       root.git.remote,
       root.git.push_proposals,
+      root.git.pr_hook,
     );
     roots[name] = { root, git };
     log.info('Root configured', {

--- a/packages/en-quire/src/bin.ts
+++ b/packages/en-quire/src/bin.ts
@@ -95,6 +95,24 @@ async function main() {
     });
   }
 
+  // Startup sync: fetch+prune per git-enabled root so `doc_proposals_list`
+  // is current from the first call. Graceful offline — a fetch failure
+  // logs a warning but does not halt startup.
+  for (const [name, rootCtx] of Object.entries(roots)) {
+    const git = rootCtx.git;
+    if (!git?.available) continue;
+    try {
+      const result = await git.fetchAndPrune();
+      if (result.ok) {
+        log.info('Proposal sync on startup', { root: name });
+      } else if (result.warning) {
+        log.warn('Proposal sync on startup failed', { root: name, warning: result.warning });
+      }
+    } catch (err) {
+      log.warn('Proposal sync on startup errored', { root: name, error: String(err) });
+    }
+  }
+
   // Sync search index per root
   for (const [name, root] of Object.entries(config.document_roots)) {
     if (config.search.sync_on_start === 'background') {

--- a/packages/en-quire/src/bin.ts
+++ b/packages/en-quire/src/bin.ts
@@ -78,7 +78,7 @@ async function main() {
   // Initialise per-root state (git operations)
   const roots: Record<string, RootContext> = {};
   for (const [name, root] of Object.entries(config.document_roots)) {
-    const git = new GitOperations(root.path, root.git.enabled);
+    const git = new GitOperations(root.path, root.git.enabled, root.git.default_branch);
     roots[name] = { root, git };
     log.info('Root configured', {
       name,

--- a/packages/en-quire/src/bin.ts
+++ b/packages/en-quire/src/bin.ts
@@ -78,7 +78,13 @@ async function main() {
   // Initialise per-root state (git operations)
   const roots: Record<string, RootContext> = {};
   for (const [name, root] of Object.entries(config.document_roots)) {
-    const git = new GitOperations(root.path, root.git.enabled, root.git.default_branch);
+    const git = new GitOperations(
+      root.path,
+      root.git.enabled,
+      root.git.default_branch,
+      root.git.remote,
+      root.git.push_proposals,
+    );
     roots[name] = { root, git };
     log.info('Root configured', {
       name,

--- a/packages/en-quire/src/parsers/markdown-parser.ts
+++ b/packages/en-quire/src/parsers/markdown-parser.ts
@@ -232,22 +232,29 @@ function findSetextHeadings(ast: Root, content: string): string[] {
 
 /**
  * Walk the section tree and find duplicate sibling headings
- * (same heading text under the same parent).
+ * (same heading text under the same parent). Each warning includes the
+ * duplicate's index path so the agent can target it via index addressing.
  */
 function findDuplicateSiblings(nodes: SectionNode[], parentPath?: string): string[] {
   const warnings: string[] = [];
-  const seen = new Set<string>();
+  const seen = new Map<string, SectionNode>();
 
   for (const node of nodes) {
     // Skip preamble — it's synthetic and always unique
     if (node.heading.text === '__preamble') continue;
 
     const key = node.heading.text;
-    if (seen.has(key)) {
+    const firstSeen = seen.get(key);
+    if (firstSeen) {
       const context = parentPath ? ` under "${parentPath}"` : ' at top level';
-      warnings.push(`Duplicate sibling heading "${key}"${context} — this will cause ambiguous section addressing.`);
+      const firstIdx = JSON.stringify(buildIndexPath(firstSeen));
+      const dupIdx = JSON.stringify(buildIndexPath(node));
+      warnings.push(
+        `Duplicate sibling heading "${key}"${context} — index ${firstIdx} and ${dupIdx} both match. ` +
+        `Address one by index (e.g. {"type":"index","indices":${dupIdx}}) or rename one of them.`,
+      );
     } else {
-      seen.add(key);
+      seen.set(key, node);
     }
 
     // Recurse into children
@@ -257,6 +264,17 @@ function findDuplicateSiblings(nodes: SectionNode[], parentPath?: string): strin
   }
 
   return warnings;
+}
+
+/** Walk parents to produce the index path that uniquely identifies this node. */
+function buildIndexPath(node: SectionNode): number[] {
+  const path: number[] = [];
+  let curr: SectionNode | null = node;
+  while (curr) {
+    path.unshift(curr.index);
+    curr = curr.parent;
+  }
+  return path;
 }
 
 /**

--- a/packages/en-quire/src/tools/admin/doc-exec.ts
+++ b/packages/en-quire/src/tools/admin/doc-exec.ts
@@ -7,6 +7,7 @@ import { safePath } from '@nullproof-studio/en-core';
 import { requirePermission } from '@nullproof-studio/en-core';
 import { logExecAudit } from '@nullproof-studio/en-core';
 import { tokeniseCommand } from '@nullproof-studio/en-core';
+import { NotFoundError, rankByLevenshtein } from '@nullproof-studio/en-core';
 
 const execFileAsync = promisify(execFile);
 
@@ -30,7 +31,13 @@ export async function handleDocExec(
   const rootName = args.root ?? Object.keys(ctx.config.document_roots)[0];
   const root = ctx.config.document_roots[rootName];
   if (!root) {
-    throw new Error(`Unknown root "${rootName}". Available: ${Object.keys(ctx.config.document_roots).join(', ')}`);
+    const candidates = rankByLevenshtein(rootName ?? '', Object.keys(ctx.config.document_roots), 20);
+    throw new NotFoundError(
+      'root',
+      rootName ?? '',
+      candidates,
+      'Set the `root` parameter to a configured root name.',
+    );
   }
   const workDir = args.working_dir
     ? safePath(root.path, args.working_dir)

--- a/packages/en-quire/src/tools/admin/doc-exec.ts
+++ b/packages/en-quire/src/tools/admin/doc-exec.ts
@@ -6,6 +6,7 @@ import type { ToolContext } from '@nullproof-studio/en-core';
 import { safePath } from '@nullproof-studio/en-core';
 import { requirePermission } from '@nullproof-studio/en-core';
 import { logExecAudit } from '@nullproof-studio/en-core';
+import { tokeniseCommand } from '@nullproof-studio/en-core';
 
 const execFileAsync = promisify(execFile);
 
@@ -16,61 +17,8 @@ export const DocExecSchema = z.object({
   root: z.string().optional().describe('Root name to use as working directory. If omitted, uses the first configured root.'),
 });
 
-/**
- * Tokenise a shell-style command string into [program, ...args].
- * Handles single quotes, double quotes, and escaped characters.
- * Does NOT process shell expansions, redirections, or pipes.
- */
-export function tokeniseCommand(command: string): string[] {
-  const tokens: string[] = [];
-  let current = '';
-  let inSingle = false;
-  let inDouble = false;
-  let escaped = false;
-  let hasQuoted = false; // Track whether current token contains quoted content
-
-  for (const ch of command) {
-    if (escaped) {
-      current += ch;
-      escaped = false;
-      continue;
-    }
-
-    if (ch === '\\' && !inSingle) {
-      escaped = true;
-      continue;
-    }
-
-    if (ch === "'" && !inDouble) {
-      inSingle = !inSingle;
-      hasQuoted = true;
-      continue;
-    }
-
-    if (ch === '"' && !inSingle) {
-      inDouble = !inDouble;
-      hasQuoted = true;
-      continue;
-    }
-
-    if (/\s/.test(ch) && !inSingle && !inDouble) {
-      if (current.length > 0 || hasQuoted) {
-        tokens.push(current);
-        current = '';
-        hasQuoted = false;
-      }
-      continue;
-    }
-
-    current += ch;
-  }
-
-  if (current.length > 0 || hasQuoted) {
-    tokens.push(current);
-  }
-
-  return tokens;
-}
+// Re-export for test suites still importing from this module
+export { tokeniseCommand };
 
 export async function handleDocExec(
   args: z.infer<typeof DocExecSchema>,

--- a/packages/en-quire/src/tools/write/doc-create.ts
+++ b/packages/en-quire/src/tools/write/doc-create.ts
@@ -77,6 +77,13 @@ export async function handleDocCreate(
         userMessage: args.message,
       });
       commit = await git.commitFile(resolved.relativePath, commitMsg);
+
+      if (mode === 'propose' && branch) {
+        const pushResult = await git.pushProposalBranch(branch);
+        if (pushResult.warning) {
+          createWarnings.push(pushResult.warning);
+        }
+      }
     }
 
     // Index the new document (use prefixed path)

--- a/packages/en-quire/src/tools/write/doc-create.ts
+++ b/packages/en-quire/src/tools/write/doc-create.ts
@@ -9,6 +9,7 @@ import { computeEtag } from '@nullproof-studio/en-core';
 import { parserRegistry } from '@nullproof-studio/en-core';
 import { indexDocument } from '@nullproof-studio/en-core';
 import { buildCommitMessage, buildProposalBranch } from '@nullproof-studio/en-core';
+import { runPostProposeHooks, getLogger } from '@nullproof-studio/en-core';
 import { requirePermission, resolveWriteMode } from '@nullproof-studio/en-core';
 import { GitRequiredError, ValidationError } from '@nullproof-studio/en-core';
 import { resolveFilePath } from '@nullproof-studio/en-core';
@@ -79,10 +80,11 @@ export async function handleDocCreate(
       commit = await git.commitFile(resolved.relativePath, commitMsg);
 
       if (mode === 'propose' && branch) {
-        const pushResult = await git.pushProposalBranch(branch);
-        if (pushResult.warning) {
-          createWarnings.push(pushResult.warning);
-        }
+        createWarnings.push(...await runPostProposeHooks(
+          git,
+          { branch, file: args.file, caller: ctx.caller.id },
+          getLogger(),
+        ));
       }
     }
 

--- a/packages/en-quire/src/tools/write/doc-generate-toc.ts
+++ b/packages/en-quire/src/tools/write/doc-generate-toc.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import type { ToolContext } from '@nullproof-studio/en-core';
 import { requirePermission } from '@nullproof-studio/en-core';
 import { ValidationError } from '@nullproof-studio/en-core';
-import { loadDocument, executeWrite } from '@nullproof-studio/en-core';
+import { loadDocument, executeWrite, parserRegistry } from '@nullproof-studio/en-core';
 
 export const DocGenerateTocSchema = z.object({
   file: z.string().describe('Document path (e.g. "root/path/to/file.md"). Markdown only — not supported for YAML.'),
@@ -24,8 +24,10 @@ export async function handleDocGenerateToc(
   const { content, encoding, tree, parser } = loadDocument(ctx, args.file);
 
   if (!parser.capabilities.generateToc || !parser.ops.generateToc) {
+    const supported = parserRegistry.extensionsSupporting('generateToc');
     throw new ValidationError(
-      'Table of contents generation is not supported for this file format.',
+      `Table of contents generation is not supported for this file format. ` +
+      `Supported: ${supported.join(', ')}.`,
     );
   }
 

--- a/packages/en-quire/src/tools/write/doc-rename.ts
+++ b/packages/en-quire/src/tools/write/doc-rename.ts
@@ -65,6 +65,7 @@ export async function handleDocRename(
 
   let branch: string | undefined;
   const originalBranch = git?.available ? await git.getCurrentBranch() : undefined;
+  const renameWarnings: string[] = [];
 
   try {
     if (mode === 'propose' && git?.available) {
@@ -88,12 +89,28 @@ export async function handleDocRename(
         [srcResolved.relativePath, destResolved.relativePath],
         commitMsg,
       );
+
+      if (mode === 'propose' && branch) {
+        const pushResult = await git.pushProposalBranch(branch);
+        if (pushResult.warning) {
+          renameWarnings.push(pushResult.warning);
+        }
+      }
     }
 
     // Update search index (remove old prefixed path)
     removeFromIndex(ctx.db, srcResolved.prefixedPath);
 
-    return { success: true, source: args.source, destination: args.destination, mode, branch, commit, etag: sourceEtag };
+    return {
+      success: true,
+      source: args.source,
+      destination: args.destination,
+      mode,
+      branch,
+      commit,
+      etag: sourceEtag,
+      ...(renameWarnings.length > 0 && { warnings: renameWarnings }),
+    };
   } finally {
     if (mode === 'propose' && originalBranch && git?.available) {
       await git.switchBranch(originalBranch);

--- a/packages/en-quire/src/tools/write/doc-rename.ts
+++ b/packages/en-quire/src/tools/write/doc-rename.ts
@@ -6,6 +6,7 @@ import { safePath, readDocument } from '@nullproof-studio/en-core';
 import { computeEtag, validateEtag } from '@nullproof-studio/en-core';
 import { removeFromIndex } from '@nullproof-studio/en-core';
 import { buildCommitMessage, buildProposalBranch } from '@nullproof-studio/en-core';
+import { runPostProposeHooks, getLogger } from '@nullproof-studio/en-core';
 import { requirePermission, resolveWriteMode } from '@nullproof-studio/en-core';
 import { NotFoundError, ValidationError, GitRequiredError } from '@nullproof-studio/en-core';
 import { resolveFilePath } from '@nullproof-studio/en-core';
@@ -91,10 +92,11 @@ export async function handleDocRename(
       );
 
       if (mode === 'propose' && branch) {
-        const pushResult = await git.pushProposalBranch(branch);
-        if (pushResult.warning) {
-          renameWarnings.push(pushResult.warning);
-        }
+        renameWarnings.push(...await runPostProposeHooks(
+          git,
+          { branch, file: args.destination, caller: ctx.caller.id },
+          getLogger(),
+        ));
       }
     }
 

--- a/packages/en-quire/test/unit/document/duplicate-siblings.test.ts
+++ b/packages/en-quire/test/unit/document/duplicate-siblings.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect } from 'vitest';
+import { parserRegistry } from '@nullproof-studio/en-core';
+import '../../../src/parsers/markdown-parser.js';
+
+const parser = parserRegistry.getParser('test.md');
+
+describe('duplicate sibling validation', () => {
+  it('warning identifies the duplicate by index path so agent can disambiguate', () => {
+    // Two top-level "## Foo" siblings.
+    const md = '# Doc\n\n## Foo\n\nA.\n\n## Bar\n\nx.\n\n## Foo\n\nB.\n';
+    const warnings = parser.validate(md);
+    const dupWarnings = warnings.filter((w) => w.includes('Duplicate sibling'));
+    expect(dupWarnings.length).toBe(1);
+    // The warning should include the index path of the duplicate so the agent
+    // can target it via {type: "index", indices: [...]} on a follow-up call.
+    expect(dupWarnings[0]).toMatch(/index\s*\[\s*\d/);
+    // And should still mention the duplicate's heading text.
+    expect(dupWarnings[0]).toContain('Foo');
+  });
+
+  it('warning identifies the parent path for nested duplicates', () => {
+    // Two "### Foo" siblings under "## Section A".
+    const md = '# Doc\n\n## Section A\n\n### Foo\n\nA.\n\n### Foo\n\nB.\n';
+    const warnings = parser.validate(md);
+    const dupWarnings = warnings.filter((w) => w.includes('Duplicate sibling'));
+    expect(dupWarnings.length).toBe(1);
+    expect(dupWarnings[0]).toContain('Section A');
+    expect(dupWarnings[0]).toMatch(/index\s*\[\s*\d/);
+  });
+});

--- a/packages/en-quire/test/unit/document/parser-registry.test.ts
+++ b/packages/en-quire/test/unit/document/parser-registry.test.ts
@@ -40,6 +40,15 @@ describe('ParserRegistry', () => {
   it('is case-insensitive for extensions', () => {
     expect(() => parserRegistry.getParser('CONFIG.YAML')).not.toThrow();
   });
+
+  it('lists extensions supporting a capability (generateToc)', () => {
+    const exts = parserRegistry.extensionsSupporting('generateToc');
+    // Markdown declares generateToc: true; YAML does not.
+    expect(exts).toContain('.md');
+    expect(exts).toContain('.mdx');
+    expect(exts).not.toContain('.yaml');
+    expect(exts).not.toContain('.yml');
+  });
 });
 
 describe('DocumentParser — validate', () => {

--- a/packages/en-quire/test/unit/document/section-address.test.ts
+++ b/packages/en-quire/test/unit/document/section-address.test.ts
@@ -211,4 +211,43 @@ describe('resolveSingleSection', () => {
       resolveSingleSection(tree, { type: 'pattern', pattern: 'Section*' }),
     ).toThrow(AddressResolutionError);
   });
+
+  it('emits distinguishable candidates when duplicate-named siblings collide', () => {
+    // Two top-level "Reinforcement Rules" siblings — text-address resolution is ambiguous.
+    const md = '# Doc\n\n## Reinforcement Rules\n\nA.\n\n## Other\n\nx.\n\n## Reinforcement Rules\n\nB.\n';
+    const ast = parseMarkdown(md);
+    const tree = buildSectionTree(ast, md);
+    let caught: unknown;
+    try {
+      resolveSingleSection(tree, { type: 'text', text: 'Reinforcement Rules' });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AddressResolutionError);
+    const err = caught as AddressResolutionError;
+    expect(err.candidates).toBeDefined();
+    expect(err.candidates!.length).toBe(2);
+    // Candidates must be distinguishable — listing the same string twice is useless.
+    expect(err.candidates![0]).not.toBe(err.candidates![1]);
+    // At least one form of actionable disambiguator should appear (index path).
+    expect(err.candidates!.every((c) => /\[\s*\d/.test(c))).toBe(true);
+  });
+
+  it('emits distinguishable candidates for nested duplicate-named sections', () => {
+    // Two "Foo" sections under different parents — same heading text, different paths.
+    const md = '# Doc\n\n## Section A\n\n### Foo\n\nA-foo.\n\n## Section B\n\n### Foo\n\nB-foo.\n';
+    const ast = parseMarkdown(md);
+    const tree = buildSectionTree(ast, md);
+    let caught: unknown;
+    try {
+      resolveSingleSection(tree, { type: 'text', text: 'Foo' });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AddressResolutionError);
+    const err = caught as AddressResolutionError;
+    // Each candidate should mention its parent path so the agent can disambiguate by path.
+    expect(err.candidates!.some((c) => c.includes('Section A'))).toBe(true);
+    expect(err.candidates!.some((c) => c.includes('Section B'))).toBe(true);
+  });
 });

--- a/packages/en-quire/test/unit/document/section-address.test.ts
+++ b/packages/en-quire/test/unit/document/section-address.test.ts
@@ -233,6 +233,28 @@ describe('resolveSingleSection', () => {
     expect(err.candidates!.every((c) => /\[\s*\d/.test(c))).toBe(true);
   });
 
+  it('ranks not-found candidates by Levenshtein distance, closest first', () => {
+    // Headings with various edit distances to the query "Foo".
+    const md = '# Doc\n\n## Foe\n\nx.\n\n## Foobar\n\ny.\n\n## Bar\n\nz.\n\n## Fop\n\nq.\n';
+    const ast = parseMarkdown(md);
+    const tree = buildSectionTree(ast, md);
+    let caught: unknown;
+    try {
+      resolveSingleSection(tree, { type: 'text', text: 'Foo' });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AddressResolutionError);
+    const err = caught as AddressResolutionError;
+    expect(err.candidates).toBeDefined();
+    // Closest matches by edit distance: Foe (1), Fop (1), then Foobar (3).
+    // Substring-only matching put Foobar first historically because it contained "Foo".
+    // Levenshtein-ranked output should put the distance-1 matches first.
+    expect(err.candidates![0]).toMatch(/^(Foe|Fop)$/);
+    expect(err.candidates![1]).toMatch(/^(Foe|Fop)$/);
+    expect(err.candidates!.slice(0, 2)).not.toContain('Foobar');
+  });
+
   it('emits distinguishable candidates for nested duplicate-named sections', () => {
     // Two "Foo" sections under different parents — same heading text, different paths.
     const md = '# Doc\n\n## Section A\n\n### Foo\n\nA-foo.\n\n## Section B\n\n### Foo\n\nB-foo.\n';

--- a/packages/en-quire/test/unit/document/section-ops.test.ts
+++ b/packages/en-quire/test/unit/document/section-ops.test.ts
@@ -403,6 +403,24 @@ describe('findReplace', () => {
     ).toThrow('Expected 2 matches but found 3');
   });
 
+  it('expected_count mismatch throws a typed ValidationError with actual_count and a preview hint', async () => {
+    const { ValidationError } = await import('@nullproof-studio/en-core');
+    const md = '# Doc\n\nHello Hello Hello\n';
+    const tree = parse(md);
+    let caught: unknown;
+    try {
+      findReplace(md, tree, 'Hello', 'Hi', { expected_count: 2 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ValidationError);
+    const err = caught as Error & { actual_count?: number; expected_count?: number };
+    expect(err.actual_count).toBe(3);
+    expect(err.expected_count).toBe(2);
+    // Message should suggest preview: true so the agent can inspect matches before retrying.
+    expect(err.message).toMatch(/preview/i);
+  });
+
   it('applies only selected matches', () => {
     const md = '# Doc\n\nA B A B A\n';
     const tree = parse(md);

--- a/packages/en-quire/test/unit/tools/exec-root-error.test.ts
+++ b/packages/en-quire/test/unit/tools/exec-root-error.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { handleDocExec } from '../../../src/tools/admin/doc-exec.js';
+import { NotFoundError } from '@nullproof-studio/en-core';
+import type {
+  ToolContext,
+  ResolvedConfig,
+  CallerIdentity,
+} from '@nullproof-studio/en-core';
+
+function makeCtx(): ToolContext {
+  const config: ResolvedConfig = {
+    document_roots: {
+      docs: { name: 'docs', path: '/tmp/docs', git: { enabled: false, auto_commit: false, branch_prefix: '' } },
+      skills: { name: 'skills', path: '/tmp/skills', git: { enabled: false, auto_commit: false, branch_prefix: '' } },
+      memory: { name: 'memory', path: '/tmp/memory', git: { enabled: false, auto_commit: false, branch_prefix: '' } },
+    },
+    database: ':memory:',
+    transport: 'stdio',
+    port: 0,
+    search: { fulltext: false, sync_on_start: 'blocking', batch_size: 100, semantic: { enabled: false } },
+    logging: { console: 'error' },
+    callers: {},
+    require_read_before_write: false,
+  };
+  const caller: CallerIdentity = {
+    id: 'test',
+    scopes: [{ path: '**', permissions: ['exec'] }],
+  };
+  // Unknown-root path is reached before any per-root state is consulted — leave roots empty.
+  return { config, roots: {}, caller, db: new Database(':memory:') };
+}
+
+describe('doc_exec unknown root', () => {
+  it('throws NotFoundError with ranked candidates and a format hint', async () => {
+    const ctx = makeCtx();
+    let caught: unknown;
+    try {
+      await handleDocExec(
+        { command: 'echo', args: ['hello'], root: 'docz' },
+        ctx,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(NotFoundError);
+    const err = caught as NotFoundError;
+    expect(err.resource).toBe('root');
+    expect(err.candidates).toBeDefined();
+    // 'docs' is closest to 'docz' (distance 1) — should rank first
+    expect(err.candidates![0]).toBe('docs');
+    expect(err.message).toMatch(/root parameter|configured root/i);
+  });
+});

--- a/packages/en-scribe/README.md
+++ b/packages/en-scribe/README.md
@@ -26,4 +26,26 @@ Two primitives — `text_find`, `text_replace_range` — can express any edit. T
 
 No regex. The positioning is *predictable, no hidden semantics*; agents wanting pattern power reach for `grep` or en-quire.
 
+## Governance workflow
+
+Proposals can become real pull requests on GitHub/GitLab. Configure the remote, the push flag, and a `pr_hook` on a root:
+
+```yaml
+document_roots:
+  notes:
+    path: /data/notes
+    git:
+      remote: origin
+      push_proposals: true
+      pr_hook: "gh pr create --head {branch} --title 'Proposal: {file}' --base main"
+```
+
+Every `mode: "propose"` write then runs the full pipeline:
+
+1. Commits to a `propose/<caller>/<path>/<timestamp>` branch locally
+2. Pushes to the remote
+3. Fires `pr_hook` with `{branch}` / `{file}` / `{caller}` substitution (via `execFile` — no shell)
+
+Approvals happen via `text_proposal_approve` (merges locally after verifying the remote branch still exists — fails closed if it was merged upstream already) or via the PR UI on your host. Server startup runs `git fetch --prune` per git-enabled root so `text_proposals_list` stays current across sessions.
+
 See the [repo README](https://github.com/nullproof-studio/en-quire#readme) for configuration and the full spec.

--- a/packages/en-scribe/package.json
+++ b/packages/en-scribe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nullproof-studio/en-scribe",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Reliable plain-text editing for agent systems. A sibling MCP to en-quire: literal range + anchor ops, no structural interpretation.",
   "type": "module",
   "main": "dist/bin.js",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@nullproof-studio/en-core": "0.1.5",
+    "@nullproof-studio/en-core": "0.2.0",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/packages/en-scribe/src/bin.ts
+++ b/packages/en-scribe/src/bin.ts
@@ -72,7 +72,7 @@ async function main() {
 
   const roots: Record<string, RootContext> = {};
   for (const [name, root] of Object.entries(config.document_roots)) {
-    const git = new GitOperations(root.path, root.git.enabled);
+    const git = new GitOperations(root.path, root.git.enabled, root.git.default_branch);
     roots[name] = { root, git };
     log.info('Root configured', {
       name,

--- a/packages/en-scribe/src/bin.ts
+++ b/packages/en-scribe/src/bin.ts
@@ -78,6 +78,7 @@ async function main() {
       root.git.default_branch,
       root.git.remote,
       root.git.push_proposals,
+      root.git.pr_hook,
     );
     roots[name] = { root, git };
     log.info('Root configured', {

--- a/packages/en-scribe/src/bin.ts
+++ b/packages/en-scribe/src/bin.ts
@@ -89,6 +89,24 @@ async function main() {
     });
   }
 
+  // Startup sync: fetch+prune per git-enabled root so `text_proposals_list`
+  // is current from the first call. Graceful offline — a fetch failure
+  // logs a warning but does not halt startup.
+  for (const [name, rootCtx] of Object.entries(roots)) {
+    const git = rootCtx.git;
+    if (!git?.available) continue;
+    try {
+      const result = await git.fetchAndPrune();
+      if (result.ok) {
+        log.info('Proposal sync on startup', { root: name });
+      } else if (result.warning) {
+        log.warn('Proposal sync on startup failed', { root: name, warning: result.warning });
+      }
+    } catch (err) {
+      log.warn('Proposal sync on startup errored', { root: name, error: String(err) });
+    }
+  }
+
   // Plaintext index sync — a single FTS row per file via the whole-file
   // pseudo-section. Line-chunked indexing for text_search ships later.
   for (const [name, root] of Object.entries(config.document_roots)) {

--- a/packages/en-scribe/src/bin.ts
+++ b/packages/en-scribe/src/bin.ts
@@ -72,7 +72,13 @@ async function main() {
 
   const roots: Record<string, RootContext> = {};
   for (const [name, root] of Object.entries(config.document_roots)) {
-    const git = new GitOperations(root.path, root.git.enabled, root.git.default_branch);
+    const git = new GitOperations(
+      root.path,
+      root.git.enabled,
+      root.git.default_branch,
+      root.git.remote,
+      root.git.push_proposals,
+    );
     roots[name] = { root, git };
     log.info('Root configured', {
       name,

--- a/packages/en-scribe/src/bin.ts
+++ b/packages/en-scribe/src/bin.ts
@@ -36,7 +36,7 @@ interface ServerDependencies {
 function createServer(deps: ServerDependencies): McpServer {
   const server = new McpServer({
     name: 'en-scribe',
-    version: '0.1.0',
+    version: '0.2.0',
   });
 
   const ctx: ToolContext = {

--- a/packages/en-scribe/src/tools/write/text-create.ts
+++ b/packages/en-scribe/src/tools/write/text-create.ts
@@ -61,6 +61,7 @@ export async function handleTextCreate(
     writeDocument(resolved.root.path, resolved.relativePath, args.content);
 
     let commit: string | undefined;
+    const pushWarnings: string[] = [];
     if (git?.available) {
       const commitMsg = buildCommitMessage({
         operation: 'Create text file',
@@ -71,6 +72,11 @@ export async function handleTextCreate(
         userMessage: args.message,
       });
       commit = await git.commitFile(resolved.relativePath, commitMsg);
+
+      if (mode === 'propose' && branch) {
+        const pushResult = await git.pushProposalBranch(branch);
+        if (pushResult.warning) pushWarnings.push(pushResult.warning);
+      }
     }
 
     try {
@@ -88,6 +94,7 @@ export async function handleTextCreate(
       branch,
       commit,
       etag: computeEtag(args.content),
+      ...(pushWarnings.length > 0 && { warnings: pushWarnings }),
     };
   } finally {
     if (mode === 'propose' && originalBranch && git?.available) {

--- a/packages/en-scribe/src/tools/write/text-create.ts
+++ b/packages/en-scribe/src/tools/write/text-create.ts
@@ -11,6 +11,8 @@ import {
   indexDocument,
   buildCommitMessage,
   buildProposalBranch,
+  runPostProposeHooks,
+  getLogger,
   requirePermission,
   resolveWriteMode,
   GitRequiredError,
@@ -74,8 +76,11 @@ export async function handleTextCreate(
       commit = await git.commitFile(resolved.relativePath, commitMsg);
 
       if (mode === 'propose' && branch) {
-        const pushResult = await git.pushProposalBranch(branch);
-        if (pushResult.warning) pushWarnings.push(pushResult.warning);
+        pushWarnings.push(...await runPostProposeHooks(
+          git,
+          { branch, file: args.file, caller: ctx.caller.id },
+          getLogger(),
+        ));
       }
     }
 

--- a/packages/en-scribe/src/tools/write/text-delete.ts
+++ b/packages/en-scribe/src/tools/write/text-delete.ts
@@ -60,6 +60,7 @@ export async function handleTextDelete(
     unlinkSync(absolutePath);
 
     let commit: string | undefined;
+    const pushWarnings: string[] = [];
     if (git?.available) {
       const commitMsg = buildCommitMessage({
         operation: 'Delete text file',
@@ -70,11 +71,23 @@ export async function handleTextDelete(
         userMessage: args.message,
       });
       commit = await git.commitFile(resolved.relativePath, commitMsg);
+
+      if (mode === 'propose' && branch) {
+        const pushResult = await git.pushProposalBranch(branch);
+        if (pushResult.warning) pushWarnings.push(pushResult.warning);
+      }
     }
 
     removeFromIndex(ctx.db, resolved.prefixedPath);
 
-    return { success: true, file: args.file, mode, branch, commit };
+    return {
+      success: true,
+      file: args.file,
+      mode,
+      branch,
+      commit,
+      ...(pushWarnings.length > 0 && { warnings: pushWarnings }),
+    };
   } finally {
     if (mode === 'propose' && originalBranch && git?.available) {
       await git.switchBranch(originalBranch);

--- a/packages/en-scribe/src/tools/write/text-delete.ts
+++ b/packages/en-scribe/src/tools/write/text-delete.ts
@@ -10,6 +10,8 @@ import {
   removeFromIndex,
   buildCommitMessage,
   buildProposalBranch,
+  runPostProposeHooks,
+  getLogger,
   requirePermission,
   resolveWriteMode,
   NotFoundError,
@@ -73,8 +75,11 @@ export async function handleTextDelete(
       commit = await git.commitFile(resolved.relativePath, commitMsg);
 
       if (mode === 'propose' && branch) {
-        const pushResult = await git.pushProposalBranch(branch);
-        if (pushResult.warning) pushWarnings.push(pushResult.warning);
+        pushWarnings.push(...await runPostProposeHooks(
+          git,
+          { branch, file: args.file, caller: ctx.caller.id },
+          getLogger(),
+        ));
       }
     }
 

--- a/packages/en-scribe/src/tools/write/text-rename.ts
+++ b/packages/en-scribe/src/tools/write/text-rename.ts
@@ -71,6 +71,7 @@ export async function handleTextRename(
 
   let branch: string | undefined;
   const originalBranch = git?.available ? await git.getCurrentBranch() : undefined;
+  const pushWarnings: string[] = [];
 
   try {
     if (mode === 'propose' && git?.available) {
@@ -94,6 +95,11 @@ export async function handleTextRename(
         [srcResolved.relativePath, destResolved.relativePath],
         commitMsg,
       );
+
+      if (mode === 'propose' && branch) {
+        const pushResult = await git.pushProposalBranch(branch);
+        if (pushResult.warning) pushWarnings.push(pushResult.warning);
+      }
     }
 
     removeFromIndex(ctx.db, srcResolved.prefixedPath);
@@ -106,6 +112,7 @@ export async function handleTextRename(
       branch,
       commit,
       etag: sourceEtag,
+      ...(pushWarnings.length > 0 && { warnings: pushWarnings }),
     };
   } finally {
     if (mode === 'propose' && originalBranch && git?.available) {

--- a/packages/en-scribe/src/tools/write/text-rename.ts
+++ b/packages/en-scribe/src/tools/write/text-rename.ts
@@ -10,6 +10,8 @@ import {
   removeFromIndex,
   buildCommitMessage,
   buildProposalBranch,
+  runPostProposeHooks,
+  getLogger,
   requirePermission,
   resolveWriteMode,
   NotFoundError,
@@ -97,8 +99,11 @@ export async function handleTextRename(
       );
 
       if (mode === 'propose' && branch) {
-        const pushResult = await git.pushProposalBranch(branch);
-        if (pushResult.warning) pushWarnings.push(pushResult.warning);
+        pushWarnings.push(...await runPostProposeHooks(
+          git,
+          { branch, file: args.destination, caller: ctx.caller.id },
+          getLogger(),
+        ));
       }
     }
 

--- a/packages/en-scribe/test/unit/tools/governance.test.ts
+++ b/packages/en-scribe/test/unit/tools/governance.test.ts
@@ -3,9 +3,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
+import { simpleGit } from 'simple-git';
 import type Database from 'better-sqlite3';
 import type { ToolContext, CallerIdentity } from '@nullproof-studio/en-core';
-import { PermissionDeniedError, ValidationError } from '@nullproof-studio/en-core';
+import { buildCommitMessage, PermissionDeniedError, ValidationError } from '@nullproof-studio/en-core';
 // Register plaintext parser so status's supportedExtensions() returns .txt/.text/.log
 import '../../../src/parsers/plaintext-parser.js';
 import { handleTextStatus } from '../../../src/tools/status/text-status.js';
@@ -58,6 +59,55 @@ describe('text_proposals_list', () => {
   it('returns empty list when no git-enabled roots', async () => {
     const result = await handleTextProposalsList({}, ctx) as { proposals: unknown[] };
     expect(result.proposals).toEqual([]);
+  });
+
+  it('hydrates section/operation/message/created/diff_summary from the tip commit', async () => {
+    // Replace the default ctx with a git-enabled one whose rootDir has
+    // been initialised before GitOperations reads .git availability.
+    db.close();
+    rmSync(rootDir, { recursive: true, force: true });
+    ({ ctx, rootDir, db } = makeCtx({ rootName: ROOT, gitEnabled: true }));
+
+    const g = simpleGit(rootDir);
+    const branchName = 'propose/michelle/notes/triage.txt/20260424T170000Z';
+    await g.checkoutLocalBranch(branchName);
+    writeFileSync(join(rootDir, 'triage.txt'), 'changed content\n');
+    await g.add('triage.txt');
+    await g.commit(buildCommitMessage({
+      operation: 'Append',
+      target: 'Triage notes',
+      file: 'notes/triage.txt',
+      caller: 'michelle',
+      mode: 'propose',
+      userMessage: 'Capture incident learnings',
+    }));
+    await g.checkout('main');
+
+    const result = await handleTextProposalsList({}, ctx) as {
+      proposals: Array<{
+        branch: string;
+        caller: string;
+        file: string;
+        section: string;
+        operation: string;
+        message: string;
+        created: string;
+        diff_summary: string;
+      }>;
+    };
+
+    expect(result.proposals).toHaveLength(1);
+    const p = result.proposals[0];
+    expect(p.branch).toBe(branchName);
+    expect(p.caller).toBe('michelle');
+    expect(p.file).toBe('notes/notes/triage.txt');
+    expect(p.section).toBe('Triage notes');
+    expect(p.operation).toBe('Append');
+    expect(p.message).toBe('Capture incident learnings');
+    // ISO 8601 commit date, not the branch-name timestamp
+    expect(p.created).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(p.created).not.toBe('20260424T170000Z');
+    expect(p.diff_summary).toMatch(/1 file changed/);
   });
 });
 


### PR DESCRIPTION
Closes #61, closes #66.

**⚠️ Draft while local PoC testing is ongoing.** Branch soaks against the testbed at [nullproofstudio/en-quire-testing](https://github.com/nullproofstudio/en-quire-testing) for a few days; will mark ready when behavioural observations from that testing are in.

## Summary

First public release across the monorepo: **v0.2.0** on all three packages. Implements everything on #61's v0.2 Governance scope plus #66's PoC finding on state reconciliation.

Eight commits, grouped by concern:

### Prerequisites (cheap correctness fixes)

- **`fix(git): lossless proposal branch ↔ file round-trip`** — Replaces lossy `/`→`-` sanitisation. Branch names now use literal `/` (git allows them); parse anchors on the fixed-length timestamp segment.
- **`feat(git): detect and honour per-root default branch`** — `resolveDefaultBranch()` precedence: configured override → `origin/HEAD` → local `main`/`master` → fallback. Replaces hardcoded `main...` in `getDiff` / `getLog`. New `git.default_branch` config.
- **`feat(git): safe approve flow + real merge_commit SHA`** — `approveProposal()` saves current branch → switches to default → merges `--no-ff` → captures `rev-parse HEAD` → deletes branch → restores in `finally`. `merge_commit` is now a real SHA instead of `''`.

### Proposal metadata hydration

- **`feat(git): hydrate proposal metadata from tip commit`** — `doc_proposals_list` returns real `section`, `operation`, `message`, `diff_summary`, `created` (ISO 8601 commit date) parsed from the structured commit message via `parseCommitMessage()` + `getProposalTipCommit()`.

### PoC target — real PRs for proposals

- **`feat(git): push proposal branches to remote behind push_proposals flag`** — After a proposal commit, push to `git.remote` when `git.push_proposals: true`. Graceful warning on failure (never throws — local commit must not be clobbered by network hiccups).
- **`feat(git): command-mode pr_hook + shared post-propose helper`** — `git.pr_hook` shell template with `{branch}` / `{file}` / `{caller}` substitution. `execFile`-hardened (no shell). Tokenise-first-then-substitute prevents argv escape from special chars in values. Shared `runPostProposeHooks()` helper de-duplicates the push + hook sequence across all 6 write paths.

### #66 drift reconciliation

- **`feat(git): startup fetch-prune + safe-approve pre-flight`** — Server startup runs `git fetch --prune` per git-enabled root (graceful offline). `approveProposal()` verifies remote branch state before merging; refuses if the proposal was merged/rejected upstream, preventing divergent history from a double-merge.

### Release

- **`chore(release): v0.2.0`** — en-core `0.1.5 → 0.2.0`, en-scribe `0.1.0 → 0.2.0`, en-quire stays `0.2.0`. Cross-package deps updated in lockstep.

## What's the user-facing surface

**New config fields** (all per-root under `git:`):

```yaml
git:
  default_branch: null      # null = auto-detect
  remote: origin            # push target
  push_proposals: true      # enable the push path
  pr_hook: "gh pr create --head {branch} --title '...'"   # runs after push
```

**New en-core exports** (public API growth):

- `GitOperations`: `resolveDefaultBranch`, `approveProposal`, `pushProposalBranch`, `runPrHook`, `fetchAndPrune`, `getProposalTipCommit`
- Helpers: `parseCommitMessage`, `parseProposalBranch`, `runPostProposeHooks`, `tokeniseCommand`

**Behaviour changes**:

- `doc_proposal_approve` / `text_proposal_approve` pre-flight-fetches when a remote is configured. Fails closed if the remote branch is gone (likely already merged upstream) or unreachable.
- Server startup runs fetch-prune per git-enabled root, so `doc_proposals_list` is current from the first call.

## Tests

- **559 unit tests** (+50 from this branch)
- **6 HTTP integration tests** (from #69)
- Coverage for every new method, plus real-repo tests for push, approve, hook, metadata hydration

## PoC evidence

First end-to-end PR through en-quire ran cleanly against the testbed yesterday — agent proposed → branch pushed → PR opened via gh → human merged on GitHub. Logs showed ~1.5s from commit to PR creation. See [testing repo PR #1](https://github.com/nullproofstudio/en-quire-testing/pull/1).

Local soak continues to observe:

- Cadence: commit-per-edit vs. session batching
- Trigger: push-on-commit vs. explicit publish
- Failure modes: push/hook error handling
- Human-review ergonomics at higher proposal volume

## Test plan

- [x] `npm test` → 559/559
- [x] `npm run test:integration` → 6/6
- [x] `npm run lint` → clean
- [x] `npm run build` → clean
- [x] End-to-end PoC against testbed (1 proposal, verified push + pr_hook + human merge)
- [ ] Multi-proposal soak — in progress
- [ ] Exit criteria from #61 — numbers for proposals/day, push failure rate, reviewer latency, cadence decision

## Out of scope (tracked elsewhere)

- Conflict detection (`can_merge` / `conflicts[]`) — deferred to v0.3
- Audit log MCP tool (`doc_audit_log`) — deferred to v0.3
- Webhook pr_hook mode — command mode proven first
- en-scribe HTTP integration tests — mirror of #72, separate follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)