### PR TITLE
ci: tag-triggered release workflow + lockstep release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+# Triggered by pushing a version tag, e.g.:
+#   git tag v0.2.0 && git push origin v0.2.0
+#
+# Publishes every workspace package at the tag's version to npm (in dependency
+# order) and cuts a matching GitHub Release. Authentication to npm uses OIDC
+# "trusted publishing" — no NPM_TOKEN secret. npm verifies the Actions run and
+# attaches a provenance attestation automatically.
+#
+# One-time setup per package on npmjs.com:
+#   Package → Settings → Publishing access → Trusted Publisher → GitHub Actions
+#   Repository: nullproof-studio/en-quire   Workflow: release.yml
+# A package must already exist on npm before its trusted publisher can be set up,
+# so brand-new packages need one initial manual `npm publish` (see PR/release notes).
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write   # create the GitHub Release
+  id-token: write   # OIDC token for npm trusted publishing + provenance
+
+jobs:
+  release:
+    name: Publish & release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 22 ships an older npm.
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Verify tag matches package versions
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          fail=0
+          for pkg in en-core en-quire en-scribe; do
+            V=$(node -p "require('./packages/$pkg/package.json').version")
+            if [ "$V" != "$TAG" ]; then
+              echo "::error::packages/$pkg is at $V but the tag is v$TAG"
+              fail=1
+            fi
+          done
+          [ "$fail" = 0 ] && echo "All packages at $TAG"
+          exit $fail
+
+      # Dependency order: en-core first (en-quire and en-scribe depend on it).
+      # Already-published versions are skipped so re-running a release is safe.
+      - name: Publish packages
+        run: |
+          for pkg in en-core en-quire en-scribe; do
+            name=$(node -p "require('./packages/$pkg/package.json').name")
+            version=$(node -p "require('./packages/$pkg/package.json').version")
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "↩︎  $name@$version already on npm — skipping"
+            else
+              echo "📦  Publishing $name@$version"
+              npm publish -w "$name"
+            fi
+          done
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            --verify-tag

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# release.sh — bump all three packages in lockstep, commit, and tag.
+#
+# Usage:
+#   scripts/release.sh <patch|minor|major|X.Y.Z> [--skip-tests]
+#
+# Examples:
+#   scripts/release.sh minor        # 0.2.0 -> 0.3.0
+#   scripts/release.sh 0.2.1        # explicit version
+#
+# What it does (nothing is pushed — that's the last manual step):
+#   1. Refuses to run on a dirty tree or off the main branch.
+#   2. Bumps version in en-core, en-quire, en-scribe to the SAME version, and
+#      updates the @nullproof-studio/en-core dependency pin in en-quire/en-scribe.
+#   3. Syncs package-lock.json, builds, and runs tests (skip with --skip-tests).
+#   4. Commits "chore(release): vX.Y.Z" and creates the matching tag.
+#
+# Then push to fire the Release workflow:
+#   git push origin main --follow-tags
+
+set -euo pipefail
+
+PACKAGES=(en-core en-quire en-scribe)
+DEPENDENTS=(en-quire en-scribe)   # packages that pin @nullproof-studio/en-core
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- args ---
+BUMP="${1:-}"
+SKIP_TESTS=0
+for a in "${@:2}"; do
+  [ "$a" = "--skip-tests" ] && SKIP_TESTS=1
+done
+if [ -z "$BUMP" ]; then
+  echo "usage: scripts/release.sh <patch|minor|major|X.Y.Z> [--skip-tests]" >&2
+  exit 1
+fi
+
+# --- preconditions ---
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" != "main" ]; then
+  echo "error: releases must be cut from 'main' (on '$branch')." >&2
+  exit 1
+fi
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: working tree is dirty — commit or stash first." >&2
+  exit 1
+fi
+
+# --- compute the new version once, from en-core ---
+NEW="$(cd packages/en-core && npm version "$BUMP" --no-git-tag-version)"
+NEW="${NEW#v}"
+echo "Releasing v$NEW"
+
+# --- apply to the other packages + dependency pins ---
+for pkg in "${PACKAGES[@]:1}"; do
+  npm version "$NEW" --no-git-tag-version -w "@nullproof-studio/$pkg" >/dev/null
+done
+for pkg in "${DEPENDENTS[@]}"; do
+  npm pkg set "dependencies.@nullproof-studio/en-core=$NEW" -w "@nullproof-studio/$pkg"
+done
+
+# --- sync lockfile, build, test ---
+npm install --package-lock-only
+npm run build
+if [ "$SKIP_TESTS" = 0 ]; then
+  npm test
+else
+  echo "⚠️  tests skipped (--skip-tests)"
+fi
+
+# --- commit + tag ---
+git add packages/*/package.json package-lock.json
+git commit -m "chore(release): v$NEW"
+git tag -a "v$NEW" -m "en-quire v$NEW"
+
+echo
+echo "✓ Committed and tagged v$NEW. To release, push:"
+echo "    git push origin main --follow-tags"


### PR DESCRIPTION
## Why

Published npm versions had no git tags or GitHub Releases, so the repo read as "never shipped" to external assessors even though `@nullproof-studio/en-quire` is live on npm. (`v0.1.5` has now been tagged/released retroactively.) This adds automation so the two sources can never drift again.

## What

**`.github/workflows/release.yml`** — triggered by pushing a `vX.Y.Z` tag:
1. Builds all packages.
2. Verifies the tag matches the `version` in all three `package.json`s (fails on drift).
3. Publishes `en-core` → `en-quire` → `en-scribe` (dependency order), skipping any version already on npm.
4. Cuts a GitHub Release with auto-generated notes.

Auth is **OIDC trusted publishing** — no `NPM_TOKEN` secret — and npm attaches a provenance attestation automatically.

**`scripts/release.sh`** — `scripts/release.sh <patch|minor|major|X.Y.Z>`:
- Guards against a dirty tree / non-`main` branch.
- Bumps all three versions **and** the `en-core` dependency pin in en-quire/en-scribe in lockstep.
- Syncs lockfile, builds, tests, commits `chore(release): vX.Y.Z`, and tags.
- Push with `git push origin main --follow-tags` to fire the workflow.

## ⚠️ One-time bootstrap before first CI release

`en-core` and `en-scribe` are not yet on npm, and trusted publishing can only be configured for packages that already exist. So before the workflow can run:
1. One manual `npm publish` of `0.2.0` for all three (creates en-core + en-scribe).
2. Configure Trusted Publisher for each package on npmjs.com → GitHub Actions → repo `nullproof-studio/en-quire`, workflow `release.yml`.

From the next release onward, `scripts/release.sh` + tag push does everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)