### PR TITLE
fix(release): PR-based lockstep flow (branch-protection + npm ci safe)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,80 +1,103 @@
 #!/usr/bin/env bash
 #
-# release.sh — bump all three packages in lockstep, commit, and tag.
+# release.sh — prepare a lockstep release PR.
 #
 # Usage:
-#   scripts/release.sh <patch|minor|major|X.Y.Z> [--skip-tests]
+#   scripts/release.sh <patch|minor|major|X.Y.Z>
 #
-# Examples:
-#   scripts/release.sh minor        # 0.2.0 -> 0.3.0
-#   scripts/release.sh 0.2.1        # explicit version
+# main is protected (PRs + status checks required), so releases go through a PR:
+#   1. This script bumps en-core, en-quire, en-scribe to the SAME version (plus
+#      the @nullproof-studio/en-core dependency pin in en-quire/en-scribe) on a
+#      release/vX.Y.Z branch, and opens a PR.
+#   2. CI validates the PR; you merge it.
+#   3. On main, run scripts/tag-release.sh to tag the merged commit, which fires
+#      the Release workflow (npm publish + provenance + GitHub Release).
 #
-# What it does (nothing is pushed — that's the last manual step):
-#   1. Refuses to run on a dirty tree or off the main branch.
-#   2. Bumps version in en-core, en-quire, en-scribe to the SAME version, and
-#      updates the @nullproof-studio/en-core dependency pin in en-quire/en-scribe.
-#   3. Syncs package-lock.json, builds, and runs tests (skip with --skip-tests).
-#   4. Commits "chore(release): vX.Y.Z" and creates the matching tag.
-#
-# Then push to fire the Release workflow:
-#   git push origin main --follow-tags
+# Version bumps are applied with `npm pkg set` (which never touches the
+# dependency tree) and the lockfile's workspace entries are patched surgically.
+# We deliberately do NOT run `npm version` or `npm install` here: those reify the
+# whole workspace and re-resolve transitive optional deps (e.g. @emnapi) for the
+# current platform, producing a lockfile that fails `npm ci` on Linux CI.
 
 set -euo pipefail
 
 PACKAGES=(en-core en-quire en-scribe)
-DEPENDENTS=(en-quire en-scribe)   # packages that pin @nullproof-studio/en-core
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-# --- args ---
 BUMP="${1:-}"
-SKIP_TESTS=0
-for a in "${@:2}"; do
-  [ "$a" = "--skip-tests" ] && SKIP_TESTS=1
-done
 if [ -z "$BUMP" ]; then
-  echo "usage: scripts/release.sh <patch|minor|major|X.Y.Z> [--skip-tests]" >&2
+  echo "usage: scripts/release.sh <patch|minor|major|X.Y.Z>" >&2
   exit 1
 fi
 
-# --- preconditions ---
+# --- preconditions: clean main, in sync with origin ---
 branch="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$branch" != "main" ]; then
-  echo "error: releases must be cut from 'main' (on '$branch')." >&2
+  echo "error: start releases from 'main' (on '$branch')." >&2
   exit 1
 fi
 if [ -n "$(git status --porcelain)" ]; then
   echo "error: working tree is dirty — commit or stash first." >&2
   exit 1
 fi
-
-# --- compute the new version once, from en-core ---
-NEW="$(cd packages/en-core && npm version "$BUMP" --no-git-tag-version)"
-NEW="${NEW#v}"
-echo "Releasing v$NEW"
-
-# --- apply to the other packages + dependency pins ---
-for pkg in "${PACKAGES[@]:1}"; do
-  npm version "$NEW" --no-git-tag-version -w "@nullproof-studio/$pkg" >/dev/null
-done
-for pkg in "${DEPENDENTS[@]}"; do
-  npm pkg set "dependencies.@nullproof-studio/en-core=$NEW" -w "@nullproof-studio/$pkg"
-done
-
-# --- sync lockfile, build, test ---
-npm install --package-lock-only
-npm run build
-if [ "$SKIP_TESTS" = 0 ]; then
-  npm test
-else
-  echo "⚠️  tests skipped (--skip-tests)"
+git fetch origin main --quiet
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+  echo "error: local main differs from origin/main — run 'git pull' first." >&2
+  exit 1
 fi
 
-# --- commit + tag ---
+# --- compute the new version ---
+CUR="$(node -p "require('./packages/en-core/package.json').version")"
+case "$BUMP" in
+  patch|minor|major)
+    NEW="$(node -e 'const v=process.argv[1].split(".").map(Number),t=process.argv[2];
+      if(t==="major"){v[0]++;v[1]=0;v[2]=0}else if(t==="minor"){v[1]++;v[2]=0}else{v[2]++}
+      console.log(v.join("."))' "$CUR" "$BUMP")"
+    ;;
+  *)
+    if ! [[ "$BUMP" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      echo "error: '$BUMP' is not a bump keyword or an X.Y.Z version." >&2
+      exit 1
+    fi
+    NEW="$BUMP"
+    ;;
+esac
+echo "Releasing v$NEW (from $CUR)"
+
+# --- branch ---
+git switch -c "release/v$NEW"
+
+# --- bump package.json versions + en-core pins (no reify) ---
+for pkg in "${PACKAGES[@]}"; do
+  npm pkg set "version=$NEW" -w "@nullproof-studio/$pkg" >/dev/null
+done
+npm pkg set "dependencies.@nullproof-studio/en-core=$NEW" -w @nullproof-studio/en-quire >/dev/null
+npm pkg set "dependencies.@nullproof-studio/en-core=$NEW" -w @nullproof-studio/en-scribe >/dev/null
+
+# --- surgically patch ONLY the workspace entries in the lockfile ---
+node -e '
+const fs=require("fs"), f="package-lock.json", NEW=process.argv[1];
+const lock=JSON.parse(fs.readFileSync(f,"utf8")), p=lock.packages;
+for (const k of ["packages/en-core","packages/en-quire","packages/en-scribe"]) p[k].version=NEW;
+for (const k of ["packages/en-quire","packages/en-scribe"]) p[k].dependencies["@nullproof-studio/en-core"]=NEW;
+fs.writeFileSync(f, JSON.stringify(lock,null,2)+"\n");
+' "$NEW"
+
+# --- commit, push, open PR ---
 git add packages/*/package.json package-lock.json
 git commit -m "chore(release): v$NEW"
-git tag -a "v$NEW" -m "en-quire v$NEW"
+git push -u origin "release/v$NEW"
+gh pr create --base main --head "release/v$NEW" \
+  --title "chore(release): v$NEW" \
+  --body "Lockstep version bump to **v$NEW** for en-core, en-quire, en-scribe (and the en-core dependency pin).
+
+After this merges and CI is green, publish from main:
+\`\`\`
+git checkout main && git pull
+scripts/tag-release.sh
+\`\`\`"
 
 echo
-echo "✓ Committed and tagged v$NEW. To release, push:"
-echo "    git push origin main --follow-tags"
+echo "✓ Opened release PR for v$NEW. Once it merges and CI is green:"
+echo "    git checkout main && git pull && scripts/tag-release.sh"

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# tag-release.sh — tag a merged release commit to trigger publishing.
+#
+# Run on main AFTER a `chore(release): vX.Y.Z` PR (from scripts/release.sh) has
+# merged. It reads the version from the packages, verifies all three agree,
+# creates the annotated tag on the current commit, and pushes it. Pushing the
+# tag fires .github/workflows/release.yml, which publishes to npm (OIDC trusted
+# publishing + provenance) and cuts the GitHub Release.
+#
+# Tags are not branch-protected, so this needs no PR.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- preconditions: clean main, in sync with origin ---
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" != "main" ]; then
+  echo "error: run from 'main' (on '$branch')." >&2
+  exit 1
+fi
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: working tree is dirty." >&2
+  exit 1
+fi
+git fetch origin main --quiet
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+  echo "error: local main is not in sync with origin/main — run 'git pull' first." >&2
+  exit 1
+fi
+
+# --- read version and verify lockstep ---
+NEW="$(node -p "require('./packages/en-core/package.json').version")"
+for pkg in en-quire en-scribe; do
+  V="$(node -p "require('./packages/$pkg/package.json').version")"
+  if [ "$V" != "$NEW" ]; then
+    echo "error: $pkg is $V but en-core is $NEW — versions are not in lockstep." >&2
+    exit 1
+  fi
+done
+
+if git rev-parse "v$NEW" >/dev/null 2>&1; then
+  echo "error: tag v$NEW already exists. Has this version already been released?" >&2
+  exit 1
+fi
+
+# --- tag + push ---
+git tag -a "v$NEW" -m "en-quire v$NEW"
+git push origin "v$NEW"
+
+echo
+echo "✓ Pushed tag v$NEW — the Release workflow will publish to npm and cut the GitHub Release."
+echo "  Watch it:  gh run watch \$(gh run list --workflow=release.yml -L1 --json databaseId -q '.[0].databaseId')"


### PR DESCRIPTION
Fixes the two failures from the first `v0.2.1` release attempt.

## 1. Lockfile drift broke `npm ci` on CI
`npm version` / `npm install` reify the whole workspace and re-resolve deep transitive **optional** deps (`@emnapi`, `@rolldown/binding-wasm32-wasi`) for the **local platform**. The lockfile that produced then failed `npm ci` on Linux:
```
npm error `npm ci` can only install packages when your package.json and
package-lock.json are in sync.
npm error Missing: @emnapi/core@1.11.0 from lock file
```
**Fix:** bump versions with `npm pkg set` (which never touches the dependency tree) and patch **only** the three workspace `version` entries + two `en-core` pins in `package-lock.json` surgically. The CI-validated cross-platform tree stays byte-identical — a 5-line lockfile diff, verified `npm ci`-consistent.

## 2. Branch protection rejected the push
`main` requires PRs + status checks, so `git push origin main --follow-tags` was rejected.
**Fix:** the release is now PR-based — the standard pattern (release-please / changesets / semantic-release all work this way under protected main):

- `scripts/release.sh <patch|minor|major|X.Y.Z>` — bumps all three packages + the en-core pin in lockstep on a `release/vX.Y.Z` branch and opens a PR.
- *(merge the PR — CI validates it like any other change)*
- `scripts/tag-release.sh` — run on `main` after merge; tags the merged commit (tags aren't branch-protected), which fires `release.yml` → npm publish (OIDC + provenance) → GitHub Release.

No bypass of branch protection; released commits pass the same gates as everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)