### PR TITLE
chore(release): v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4992,7 +4992,7 @@
     },
     "packages/en-core": {
       "name": "@nullproof-studio/en-core",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -5021,11 +5021,11 @@
     },
     "packages/en-quire": {
       "name": "@nullproof-studio/en-quire",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@nullproof-studio/en-core": "0.2.0",
+        "@nullproof-studio/en-core": "0.2.1",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.0",
         "remark-parse": "^11.0.0",
@@ -5047,11 +5047,11 @@
     },
     "packages/en-scribe": {
       "name": "@nullproof-studio/en-scribe",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@nullproof-studio/en-core": "0.2.0",
+        "@nullproof-studio/en-core": "0.2.1",
         "zod": "^3.24.4"
       },
       "bin": {

--- a/packages/en-core/package.json
+++ b/packages/en-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nullproof-studio/en-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Reliability primitives shared by the en-quire and en-scribe MCP servers: etag, proposals, diff, file-utils, git, RBAC, parser registry.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/en-quire/package.json
+++ b/packages/en-quire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nullproof-studio/en-quire",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Structured document management for agent systems, with governance. An MCP server.",
   "type": "module",
   "main": "dist/bin.js",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@nullproof-studio/en-core": "0.2.0",
+    "@nullproof-studio/en-core": "0.2.1",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",
     "remark-parse": "^11.0.0",

--- a/packages/en-scribe/package.json
+++ b/packages/en-scribe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nullproof-studio/en-scribe",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Reliable plain-text editing for agent systems. A sibling MCP to en-quire: literal range + anchor ops, no structural interpretation.",
   "type": "module",
   "main": "dist/bin.js",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@nullproof-studio/en-core": "0.2.0",
+    "@nullproof-studio/en-core": "0.2.1",
     "zod": "^3.24.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Lockstep version bump to **v0.2.1** for en-core, en-quire, en-scribe (and the en-core dependency pin).

After this merges and CI is green, publish from main:
```
git checkout main && git pull
scripts/tag-release.sh
```