### PR TITLE
chore: CI actions v6 (Node 24) + normalize repository.url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -26,8 +26,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -40,8 +40,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -52,8 +52,8 @@ jobs:
     name: Test (integration)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -67,8 +67,8 @@ jobs:
     name: Publish dry-run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
     name: Publish & release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nullproof-studio/en-quire.git"
+    "url": "git+https://github.com/nullproof-studio/en-quire.git"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/en-core/package.json
+++ b/packages/en-core/package.json
@@ -17,7 +17,7 @@
   "author": "Nullproof Studio",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nullproof-studio/en-quire.git",
+    "url": "git+https://github.com/nullproof-studio/en-quire.git",
     "directory": "packages/en-core"
   },
   "engines": {

--- a/packages/en-quire/package.json
+++ b/packages/en-quire/package.json
@@ -19,7 +19,7 @@
   "author": "Nullproof Studio",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nullproof-studio/en-quire.git",
+    "url": "git+https://github.com/nullproof-studio/en-quire.git",
     "directory": "packages/en-quire"
   },
   "keywords": [

--- a/packages/en-scribe/package.json
+++ b/packages/en-scribe/package.json
@@ -19,7 +19,7 @@
   "author": "Nullproof Studio",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nullproof-studio/en-quire.git",
+    "url": "git+https://github.com/nullproof-studio/en-quire.git",
     "directory": "packages/en-scribe"
   },
   "keywords": [


### PR DESCRIPTION
Two small housekeeping items surfaced by the v0.2.1 release.

## CI actions → v6 (Node 24)
`actions/checkout@v4` and `actions/setup-node@v4` run on Node 20, which GitHub deprecated; the runner forces Node 24 on **2026-06-16**. Bumped both to `@v6` (latest, Node 24) across `ci.yml` and `release.yml` — clears the deprecation annotation.

## Normalize `repository.url`
Every `npm publish` warned that `repository.url` was auto-normalized to `git+https://…`. Added the `git+` prefix to all four `package.json` files so npm stops rewriting it. (Removed the empty `"version": ""` that `npm pkg fix` tried to add to the private monorepo root.)

No functional/runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)