### PR TITLE
feat(release): one-click versioned release (lockstep bump + npm + GHCR)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,34 +1,64 @@
 name: Release
 
-# Triggered by pushing a version tag, e.g.:
-#   git tag v0.2.0 && git push origin v0.2.0
+# Two ways in, one pipeline out (npm ×3 + GHCR image + GitHub Release):
 #
-# Publishes every workspace package at the tag's version to npm (in dependency
-# order) and cuts a matching GitHub Release. Authentication to npm uses OIDC
-# "trusted publishing" — no NPM_TOKEN secret. npm verifies the Actions run and
-# attaches a provenance attestation automatically.
+#   1. Manual (recommended): Actions → Release → Run workflow → pick the bump
+#      (major | minor | patch) or an explicit version. The job bumps all three
+#      packages in lockstep, commits `chore(release): vX.Y.Z` to main, pushes
+#      the matching tag, then publishes everything.
 #
-# One-time setup per package on npmjs.com:
+#   2. Tag push: `git tag vX.Y.Z && git push origin vX.Y.Z` (assumes the version
+#      is already committed) — publishes at that tag.
+#
+# npm uses OIDC "trusted publishing" — no NPM_TOKEN secret; npm verifies the
+# Actions run and attaches a provenance attestation. The container image is
+# pushed to GitHub Container Registry (ghcr.io) using the built-in token.
+#
+# One-time npm setup per package on npmjs.com:
 #   Package → Settings → Publishing access → Trusted Publisher → GitHub Actions
 #   Repository: nullproof-studio/en-quire   Workflow: release.yml
-# A package must already exist on npm before its trusted publisher can be set up,
-# so brand-new packages need one initial manual `npm publish` (see PR/release notes).
+# A package must already exist on npm before its trusted publisher can be set up.
+#
+# NOTE: the manual path commits the bump directly to `main`. If `main` is a
+# protected branch, add `github-actions[bot]` to the branch-protection bypass
+# list (Settings → Branches) so the release commit can land.
 
 on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Semver bump (ignored if "version" is set)'
+        type: choice
+        required: true
+        default: patch
+        options: [patch, minor, major]
+      version:
+        description: 'Explicit version X.Y.Z (overrides bump)'
+        type: string
+        required: false
   push:
     tags:
       - 'v*'
 
 permissions:
-  contents: write   # create the GitHub Release
+  contents: write   # commit the bump, push the tag, create the GitHub Release
   id-token: write   # OIDC token for npm trusted publishing + provenance
+  packages: write   # push the image to ghcr.io
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   release:
-    name: Publish & release
+    name: Bump, publish & release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Dispatch bumps & commits to main; a tag push checks out the tag.
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
+          fetch-depth: 0
 
       - uses: actions/setup-node@v6
         with:
@@ -36,30 +66,57 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
-      # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 22 ships an older npm.
+      # Trusted publishing (OIDC) requires npm >= 11.5.1.
       - name: Update npm
         run: npm install -g npm@latest
 
       - run: npm ci
+
+      - name: Bump version (lockstep) and tag
+        id: bump
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          node scripts/bump-version.mjs "${{ inputs.version || inputs.bump }}"
+          NEW=$(node -p "require('./packages/en-core/package.json').version")
+          git add package.json package-lock.json packages/*/package.json
+          git commit -m "chore(release): v$NEW"
+          git tag "v$NEW"
+          git push origin HEAD:main
+          git push origin "v$NEW"
+
+      - name: Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = 'workflow_dispatch' ]; then
+            V=$(node -p "require('./packages/en-core/package.json').version")
+          else
+            V="${GITHUB_REF_NAME#v}"
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "tag=v$V" >> "$GITHUB_OUTPUT"
+          echo "Releasing v$V"
+
       - run: npm run build
 
       - name: Verify tag matches package versions
         run: |
-          TAG="${GITHUB_REF_NAME#v}"
+          WANT="${{ steps.ver.outputs.version }}"
           fail=0
           for pkg in en-core en-quire en-scribe; do
             V=$(node -p "require('./packages/$pkg/package.json').version")
-            if [ "$V" != "$TAG" ]; then
-              echo "::error::packages/$pkg is at $V but the tag is v$TAG"
+            if [ "$V" != "$WANT" ]; then
+              echo "::error::packages/$pkg is at $V but the release is v$WANT"
               fail=1
             fi
           done
-          [ "$fail" = 0 ] && echo "All packages at $TAG"
+          [ "$fail" = 0 ] && echo "All packages at $WANT"
           exit $fail
 
       # Dependency order: en-core first (en-quire and en-scribe depend on it).
       # Already-published versions are skipped so re-running a release is safe.
-      - name: Publish packages
+      - name: Publish packages to npm
         run: |
           for pkg in en-core en-quire en-scribe; do
             name=$(node -p "require('./packages/$pkg/package.json').name")
@@ -72,11 +129,33 @@ jobs:
             fi
           done
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image to GHCR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.ver.outputs.version }}
+            ghcr.io/${{ github.repository }}:latest
+          provenance: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
+          gh release create "${{ steps.ver.outputs.tag }}" \
+            --title "${{ steps.ver.outputs.tag }}" \
             --generate-notes \
             --verify-tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,16 @@
 # Default CMD runs enquire. For enscribe: `docker run --entrypoint enscribe ...`
 
 # ---- build stage ------------------------------------------------------------
-FROM node:22-slim AS build
+FROM node:24-slim AS build
 
 WORKDIR /app
+
+# better-sqlite3 has no prebuilt binary for every node 24 target, so node-gyp
+# may compile it from source — which needs python3 + a C++ toolchain. These
+# live only in the build stage; the runtime stage below stays slim.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy workspace manifests first so npm ci can cache deps when only code changes
 COPY package.json package-lock.json tsconfig.base.json ./
@@ -23,7 +30,7 @@ RUN npm run build
 RUN npm prune --omit=dev --workspaces --include-workspace-root
 
 # ---- runtime stage ----------------------------------------------------------
-FROM node:22-slim AS runtime
+FROM node:24-slim AS runtime
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git sqlite3 curl \

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:all": "npm run test && npm run test:integration",
+    "bump": "node scripts/bump-version.mjs",
     "lint": "tsc --noEmit -p packages/en-core && tsc --noEmit -p packages/en-quire && tsc --noEmit -p packages/en-scribe",
     "clean": "npm run clean -w @nullproof-studio/en-core --if-present && npm run clean -w @nullproof-studio/en-quire --if-present && npm run clean -w @nullproof-studio/en-scribe --if-present"
   },

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Nullproof Studio. MIT License — see LICENSE
+//
+// Lockstep version bumper for the en-quire monorepo. All publishable packages
+// (en-core, en-quire, en-scribe) share one version, and the internal
+// `@nullproof-studio/*` dependency pins are kept exactly in sync so a release
+// never ships en-quire pointing at a stale en-core. Usage:
+//
+//   node scripts/bump-version.mjs <major|minor|patch|X.Y.Z>
+//
+// Rewrites the three package.json files, refreshes package-lock.json, prints
+// the new version, and (in CI) appends `version=<new>` to $GITHUB_OUTPUT.
+import { readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const PACKAGES = ['en-core', 'en-quire', 'en-scribe'].map((p) => `packages/${p}/package.json`);
+const SOURCE_OF_TRUTH = 'packages/en-core/package.json';
+const INTERNAL_SCOPE = '@nullproof-studio/';
+const DEP_FIELDS = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'];
+
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf8'));
+const writeJson = (path, obj) => writeFileSync(path, JSON.stringify(obj, null, 2) + '\n');
+
+function parseSemver(v) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v);
+  if (!m) throw new Error(`Unsupported version "${v}" — expected plain X.Y.Z`);
+  return { major: +m[1], minor: +m[2], patch: +m[3] };
+}
+
+function nextVersion(current, arg) {
+  if (/^\d+\.\d+\.\d+$/.test(arg)) return arg; // explicit version wins
+  const { major, minor, patch } = parseSemver(current);
+  switch (arg) {
+    case 'major':
+      return `${major + 1}.0.0`;
+    case 'minor':
+      return `${major}.${minor + 1}.0`;
+    case 'patch':
+      return `${major}.${minor}.${patch + 1}`;
+    default:
+      throw new Error(`Unknown bump "${arg}" — use major | minor | patch | X.Y.Z`);
+  }
+}
+
+const arg = process.argv[2];
+if (!arg) {
+  console.error('Usage: node scripts/bump-version.mjs <major|minor|patch|X.Y.Z>');
+  process.exit(1);
+}
+
+const current = readJson(SOURCE_OF_TRUTH).version;
+const next = nextVersion(current, arg);
+if (next === current) {
+  console.error(`Refusing to bump: version is already ${next}`);
+  process.exit(1);
+}
+
+for (const path of PACKAGES) {
+  const pkg = readJson(path);
+  pkg.version = next;
+  for (const field of DEP_FIELDS) {
+    const deps = pkg[field];
+    if (!deps) continue;
+    for (const name of Object.keys(deps)) {
+      if (name.startsWith(INTERNAL_SCOPE)) deps[name] = next; // exact lockstep pin
+    }
+  }
+  writeJson(path, pkg);
+}
+
+// Sync the lockfile's recorded versions without touching node_modules.
+execFileSync('npm', ['install', '--package-lock-only'], { stdio: 'inherit' });
+
+console.log(`Bumped ${current} -> ${next}`);
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `version=${next}\n`);
+}


### PR DESCRIPTION
**Stacked on #98** (node 24). Base is `chore/ci-node-24`; GitHub will auto-retarget this to `main` once #98 merges.

## What
A single **Release** action that increments the version and publishes everything at one synchronized version — npm (×3), a GHCR image, and a GitHub Release. Supports **major/minor/patch** (or an explicit version).

## How it works
- **`npm run bump <major|minor|patch|X.Y.Z>`** (scripts/bump-version.mjs): bumps all 3 packages in lockstep, keeps the internal `@nullproof-studio/en-core` exact pins in sync, refreshes `package-lock.json`.
- **`release.yml`** is now triggered two ways:
  1. **Manual (recommended):** Actions → Release → Run workflow → pick the bump. It bumps, commits `chore(release): vX.Y.Z` to `main`, pushes the tag, then publishes.
  2. **Tag push:** `git tag vX.Y.Z && git push` (version already committed) → publishes at the tag.
- Fan-out: npm OIDC trusted publish (unchanged) + **Docker build/push to `ghcr.io/nullproof-studio/en-quire`** (`:<version>` and `:latest`, with provenance) + `gh release create --generate-notes`.
- **Dockerfile → node 24** + build-stage toolchain (python3/make/g++) so `better-sqlite3` compiles when no node-24 prebuilt exists (runtime image stays slim). Validated locally: image builds and better-sqlite3 loads on node 24.

## ⚠️ One setup step before the first manual release
The dispatch path commits the version bump directly to `main`. If `main` is protected, add **`github-actions[bot]`** to the branch-protection **bypass list** (Settings → Branches), else the release commit is rejected. (The tag-push path doesn't need this.)

Also: GHCR publishing uses the built-in token; no secret needed. The first push creates the `en-quire` package under the org (private by default — flip to public in the package settings if desired).

## Verification
bump math (patch→0.2.2 / minor→0.3.0 / major→1.0.0) ✅ · lockstep + internal-pin + lockfile sync ✅ · workflow YAML parses ✅ · `docker build` on node 24 + better-sqlite3 load ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
