### PR TITLE
ci(release): push version bump via GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,21 @@ jobs:
     name: Bump, publish & release
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived token from the release GitHub App. The app is listed
+      # as a bypass actor on the `main` branch ruleset, so the version-bump
+      # commit can be pushed directly to main (the default GITHUB_TOKEN cannot —
+      # the ruleset requires PRs). Scoped to this repo's Contents: write only.
+      - name: Generate release-app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
+          # Use the app token so pushes to main bypass the ruleset.
+          token: ${{ steps.app-token.outputs.token }}
           # Dispatch bumps & commits to main; a tag push checks out the tag.
           ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
           fetch-depth: 0


### PR DESCRIPTION
## Why

The `v0.3.0` release run failed at the "push bump to main" step:

```
! [remote rejected] HEAD -> main (push declined due to repository rule violations)
```

The **Main Rules** ruleset requires PRs (`pull_request` rule) with an **empty bypass list**, so the release workflow's direct `git push origin HEAD:main` — authenticated as the default `github-actions[bot]` — is rejected.

## Fix

Mint a short-lived token from a dedicated **release GitHub App** and use it for checkout, so the bump commit is pushed as the app (which is a ruleset bypass actor). Scoped to this repo's **Contents: write** only — no loosening of the PR requirement for humans.

## Required before the next release run

1. Create a GitHub App (org `nullproof-studio`) with **Repository → Contents: Read and write**; generate a private key; install it on `en-quire`.
2. Add repo secrets **`RELEASE_APP_ID`** and **`RELEASE_APP_PRIVATE_KEY`**.
3. Add the app to the **Main Rules** ruleset bypass list (`actor_type: Integration`).

State is clean — the failed run published nothing and created no tag; main is still at `0.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)